### PR TITLE
feat: create uncompressed chunk if it doesn't exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,9 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed"
+checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1562,6 +1562,8 @@ dependencies = [
  "postgres",
  "pretty_env_logger 0.5.0",
  "rustls",
+ "serde",
+ "serde_json",
  "test-common",
  "testcontainers",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ tokio-postgres-rustls = { version = "0.10.0", default-features = false }
 tracing = { version = "0.1.37", default-features = false, features = ["release_max_level_debug"] }
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["env-filter", "fmt", "json", "std"] }
 async-channel = "1.9.0"
+serde = { version = "1.0.171", features = ["derive"] }
+serde_json = "1.0.103"
 
 [dev-dependencies]
 assert_cmd = "2.0.11"

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,11 +1,9 @@
 use anyhow::Result;
-
-use std::sync::Arc;
-
 use rustls::{
     client::{ServerCertVerified, ServerCertVerifier},
     ClientConfig,
 };
+use std::sync::Arc;
 use tokio_postgres::IsolationLevel::Serializable;
 use tokio_postgres::{config::SslMode, Client, Config, NoTls, SimpleQueryMessage, Transaction};
 use tokio_postgres_rustls::MakeRustlsConnect;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use crate::connect::Source;
 use crate::logging::setup_logging;
-use crate::prepare::CompressionState::CompressedHypertable;
-use crate::prepare::{get_chunk_information, get_hypertable_information, Hypertable};
+use crate::prepare::{get_chunk_information, get_hypertable_information};
+use crate::timescale::{CompressionState::CompressedHypertable, Hypertable};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use clap::Parser;
@@ -14,6 +14,7 @@ mod connect;
 mod execute;
 mod logging;
 mod prepare;
+mod timescale;
 mod work_items;
 mod workers;
 
@@ -108,9 +109,6 @@ fn abort_if_hypertable_setup_not_supported(hypertables: &[Hypertable]) {
         if hypertable.compression_state == CompressedHypertable {
             // We don't care about the hypertable containing compressed data
             continue;
-        }
-        if hypertable.dimensions.len() > 1 {
-            todo!("Cannot handle hypertables with multiple dimensions")
         }
         for dimension in &hypertable.dimensions {
             if &dimension.column_type != "timestamp with time zone" {

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -1,0 +1,119 @@
+use crate::timescale::CompressionState::{CompressedHypertable, CompressionOff, CompressionOn};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum CompressionState {
+    CompressionOff,
+    CompressionOn,
+    CompressedHypertable,
+}
+
+#[derive(Debug)]
+pub struct InvalidCompressionStatusError;
+
+impl Display for InvalidCompressionStatusError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl Error for InvalidCompressionStatusError {}
+
+impl TryFrom<i16> for CompressionState {
+    type Error = InvalidCompressionStatusError;
+
+    fn try_from(value: i16) -> std::result::Result<Self, Self::Error> {
+        match value {
+            0 => Ok(CompressionOff),
+            1 => Ok(CompressionOn),
+            2 => Ok(CompressedHypertable),
+            _ => Err(InvalidCompressionStatusError),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Hypertable {
+    pub schema: String,
+    pub table: String,
+    pub dimensions: Vec<Dimension>,
+    pub compression_state: CompressionState,
+}
+
+#[derive(Debug)]
+pub struct Dimension {
+    pub column_name: String,
+    pub column_type: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DimensionRange {
+    pub column_name: String,
+    pub column_type: String,
+    pub range_start: i64,
+    pub range_end: i64,
+}
+
+#[derive(Debug)]
+pub struct Chunk {
+    pub hypertable_schema: String,
+    pub hypertable_name: String,
+    pub chunk_schema: String,
+    pub chunk_name: String,
+    /// The dimensions need to be sorted by ID ASC. The order is important
+    /// because it's used to match against other Chunk's dimensions.
+    pub dimensions: Vec<DimensionRange>,
+    pub active_chunk: bool,
+}
+
+impl Chunk {
+    /// Returns the dimensions of the Chunk as a JSON string with the format:
+    ///
+    /// ```
+    /// [{
+    ///     "column_name": "time",
+    ///     "column_type": "timestamp with timezone",
+    ///     "range_start": 100000000,
+    ///     "range_end": 200000000,
+    /// },{
+    ///     "column_name": "device_id",
+    ///     "column_type": "bigint",
+    ///     "range_start": 10,
+    ///     "range_end": 50,
+    /// },...]
+    /// ```
+    ///
+    /// The dimensions are expected to be a list sorted by dimension ID. The
+    /// purpose is to be able to use the list of dimensions from a source
+    /// Chunk and match them against a target Chunk.
+    pub fn dimension_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(&self.dimensions)
+    }
+
+    /// Returns the slices (dimensions) of the Chunk, in the format required
+    /// by the `_timescaledb_internal.create_chunk` function.
+    ///
+    /// ```
+    /// {
+    ///   "time": [100000000, 200000000],
+    ///   "device_id": [10, 50]
+    ///   ...
+    /// }
+    /// ```
+    pub fn slices(&self) -> Result<String, serde_json::Error> {
+        let mut dimensions_json = serde_json::Map::new();
+        for dimension in &self.dimensions {
+            let column_name = &dimension.column_name;
+            let range_start = dimension.range_start;
+            let range_end = dimension.range_end;
+
+            let dimension_value =
+                Value::Array(vec![Value::from(range_start), Value::from(range_end)]);
+            dimensions_json.insert(column_name.clone(), dimension_value);
+        }
+        serde_json::to_string(&dimensions_json)
+    }
+}

--- a/src/work_items.rs
+++ b/src/work_items.rs
@@ -1,4 +1,4 @@
-use crate::prepare::Chunk;
+use crate::timescale::Chunk;
 use anyhow::{Context, Result};
 use async_channel::{Receiver, Sender};
 use tracing::trace;

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -1,15 +1,12 @@
+use crate::connect::{Source, Target};
 use crate::execute::copy_chunk;
+use crate::timescale::Chunk;
 use anyhow::{Context, Result};
 use async_channel::Receiver;
 use chrono::{DateTime, Utc};
 use tokio::task::JoinSet;
 use tokio_postgres::Config;
 use tracing::{debug, trace};
-
-use crate::{
-    connect::{Source, Target},
-    prepare::Chunk,
-};
 
 /// Spawns asyncronous tasks (workers) that wait until a `Chunk` is
 /// passed via a `Receiver`, and copy the data of the `Chunk` from the source


### PR DESCRIPTION
### feat: abort when hypertable setup not supported 
 
 
### feat: create uncompressed chunk if it does not exists 
 
 When processing a Chunk from Source the tool looks for one in Target
that matches Hypertable and dimensions. If the Chunk is not found it's
created by calling the `_timescaledb_internal.create_chunk`, with the
same dimensions as in Source.

We can't match against the Chunk's ID or name because there's no
guarantee that the ID hasn't been assigned to another Chunk with
different dimensions.

closes #17 