### PR TITLE
feat: create compressed chunk if it doesn't exist

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1,5 +1,5 @@
 use crate::connect::{Source, Target};
-use crate::timescale::Chunk;
+use crate::timescale::{quote_table_name, Chunk, CompressedChunk, CompressionSize};
 use anyhow::{bail, Result};
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
@@ -10,22 +10,61 @@ use tokio_postgres::types::private::BytesMut;
 use tokio_postgres::{CopyInSink, Transaction};
 use tracing::{debug, trace};
 
+const COMPRESS_TABLE_NAME_PREFIX: &str = "bf_";
+const PG_NAME_DATA_LEN: usize = 64;
+
 pub async fn copy_chunk(
     source: &mut Source,
     target: &mut Target,
-    chunk: Chunk,
+    source_chunk: Chunk,
     until: &DateTime<Utc>,
 ) -> Result<()> {
     let source_tx = source.transaction().await?;
     let target_tx = target.client.transaction().await?;
 
-    copy_uncompressed_chunk_data(&source_tx, &target_tx, &chunk, until).await?;
+    let target_chunk = match get_chunk_with_same_dimensions(&target_tx, &source_chunk).await? {
+        Some(target_chunk) => target_chunk,
+        None => create_uncompressed_chunk(&target_tx, &source_chunk).await?,
+    };
 
-    let compressed_chunk = get_compressed_chunk(&source_tx, &chunk).await?;
-    if compressed_chunk.is_some() {
-        // TODO: create compressed chunk in target, if missing
-        let compressed_chunk = compressed_chunk.unwrap();
-        copy_compressed_chunk_data(&source_tx, &target_tx, &compressed_chunk).await?;
+    copy_uncompressed_chunk_data(&source_tx, &target_tx, &source_chunk, &target_chunk, until)
+        .await?;
+
+    if let Some(source_compressed_chunk) = get_compressed_chunk(&source_tx, &source_chunk).await? {
+        if let Some(target_compressed_chunk) =
+            get_compressed_chunk(&target_tx, &target_chunk).await?
+        {
+            copy_compressed_chunk_data(
+                &source_tx,
+                &target_tx,
+                &source_compressed_chunk,
+                &target_compressed_chunk,
+            )
+            .await?;
+        } else {
+            let target_compressed_chunk_data_table = create_compressed_chunk_data_table(
+                &target_tx,
+                &target_chunk,
+                &source_compressed_chunk.chunk_schema,
+                &source_compressed_chunk.chunk_name,
+            )
+            .await?;
+            copy_compressed_chunk_data(
+                &source_tx,
+                &target_tx,
+                &source_compressed_chunk,
+                &target_compressed_chunk_data_table,
+            )
+            .await?;
+            create_compressed_chunk_from_data_table(
+                &source_tx,
+                &target_tx,
+                &source_compressed_chunk,
+                &target_chunk,
+                &target_compressed_chunk_data_table,
+            )
+            .await?;
+        };
     }
 
     target_tx.commit().await?;
@@ -36,33 +75,21 @@ pub async fn copy_chunk(
 async fn copy_uncompressed_chunk_data(
     source_tx: &Transaction<'_>,
     target_tx: &Transaction<'_>,
-    chunk: &Chunk,
+    source_chunk: &Chunk,
+    target_chunk: &Chunk,
     until: &DateTime<Utc>,
 ) -> Result<()> {
     debug!("Copying uncompressed chunk");
-    let target_chunk = match get_chunk_with_same_dimensions(target_tx, chunk).await? {
-        Some(target_chunk) => target_chunk,
-        None => create_uncompressed_chunk(target_tx, chunk).await?,
-    };
 
-    let source_chunk_name = format!(
-        "{}.{}",
-        quote_ident(&chunk.chunk_schema),
-        quote_ident(&chunk.chunk_name)
-    );
-    let target_chunk_name = format!(
-        "{}.{}",
-        quote_ident(&target_chunk.chunk_schema),
-        quote_ident(&target_chunk.chunk_name)
-    );
+    let trigger_dropped = drop_invalidation_trigger(target_tx, &target_chunk.quoted_name()).await?;
 
-    let trigger_dropped = drop_invalidation_trigger(target_tx, &target_chunk_name).await?;
-    if !chunk.active_chunk {
-        delete_all_rows_from_chunk(target_tx, &target_chunk_name).await?;
+    if !target_chunk.active_chunk {
+        delete_all_rows_from_chunk(target_tx, &target_chunk.quoted_name()).await?;
     } else {
-        delete_data_until(target_tx, &target_chunk_name, until).await?;
+        delete_data_until(target_tx, &target_chunk.quoted_name(), until).await?;
     }
-    let until = if chunk.active_chunk {
+
+    let until = if target_chunk.active_chunk {
         Some(until)
     } else {
         None
@@ -71,13 +98,14 @@ async fn copy_uncompressed_chunk_data(
     copy_chunk_from_source_to_target(
         source_tx,
         target_tx,
-        &source_chunk_name,
-        &target_chunk_name,
+        &source_chunk.quoted_name(),
+        &target_chunk.quoted_name(),
         until,
     )
     .await?;
+
     if trigger_dropped {
-        create_invalidation_trigger(target_tx, &target_chunk_name).await?;
+        create_invalidation_trigger(target_tx, &target_chunk.quoted_name()).await?;
     }
     Ok(())
 }
@@ -169,30 +197,27 @@ async fn delete_all_rows_from_chunk(target_tx: &Transaction<'_>, chunk_name: &st
 async fn copy_compressed_chunk_data(
     source_tx: &Transaction<'_>,
     target_tx: &Transaction<'_>,
-    chunk: &CompressedChunk,
+    source_chunk: &CompressedChunk,
+    target_chunk: &CompressedChunk,
 ) -> Result<()> {
     debug!("Copying compressed chunk");
-    // TODO get actual compressed chunk name
 
-    let source_chunk_name = format!(
-        "{}.{}",
-        quote_ident(&chunk.chunk_schema),
-        quote_ident(&chunk.chunk_name)
-    );
-    let target_chunk_name = format!(
-        "{}.{}",
-        quote_ident(&chunk.chunk_schema),
-        quote_ident(&chunk.chunk_name)
-    );
+    let trigger_dropped = drop_invalidation_trigger(target_tx, &target_chunk.quoted_name()).await?;
 
     copy_chunk_from_source_to_target(
         source_tx,
         target_tx,
-        &source_chunk_name,
-        &target_chunk_name,
+        &source_chunk.quoted_name(),
+        &target_chunk.quoted_name(),
         None,
     )
-    .await
+    .await?;
+
+    if trigger_dropped {
+        create_invalidation_trigger(target_tx, &target_chunk.quoted_name()).await?;
+    }
+
+    Ok(())
 }
 
 async fn copy_chunk_from_source_to_target(
@@ -240,27 +265,6 @@ async fn copy_chunk_from_source_to_target(
     debug!("Copied {rows} for table {source_chunk_name}",);
 
     Ok(())
-}
-
-/// `quote_ident` quotes the given value as an identifier (table, schema) safely for use in a `simple_query` call.
-/// Implementation matches that of `quote_identifier` in ruleutils.c of the `PostgreSQL` code,
-/// with `quote_all_identifiers` = true.
-pub fn quote_ident(value: &str) -> String {
-    let mut result = String::with_capacity(value.len() + 4);
-    result.push('"');
-    for c in value.chars() {
-        if c == '"' {
-            result.push(c);
-        }
-        result.push(c);
-    }
-    result.push('"');
-    result
-}
-
-struct CompressedChunk {
-    chunk_schema: String,
-    chunk_name: String,
 }
 
 async fn get_compressed_chunk(
@@ -373,7 +377,7 @@ SELECT _timescaledb_internal.create_chunk(
 )
 "#,
         &[
-            &format!("{}.{}", chunk.hypertable_schema, chunk.hypertable_name,),
+            &format!("{}.{}", chunk.hypertable_schema, chunk.hypertable_name),
             &chunk.slices()?,
         ],
     )
@@ -383,4 +387,182 @@ SELECT _timescaledb_internal.create_chunk(
         Some(target_chunk) => Ok(target_chunk),
         None => bail!("failed to create chunk in target"),
     }
+}
+
+/// Creates a compressed chunk data table. The table is created in the given
+/// `schema_name` and the `table_name` is prefixed with
+/// `COMPRESS_TABLE_NAME_PREFIX`.
+///
+/// The generated table is not part of the chunks catalog, it's not associated
+/// with any uncompressed chunk and it's missing the corresponding indexes,
+/// constraints and triggers. To convert the table into a propper compressed
+/// chunk, first the compressed data has to be inserted into it, then it needs
+/// to be passed as argument to the
+/// `_timescaledb_internal.create_compressed_chunk` function.
+///
+/// Trying to generate the same chunk name as TimescaleDB (TS) might produce
+/// inconsistencies because TS uses the chunk ID as part of the name. Since we
+/// are not directly inserting into the Chunk's catalog, we cannot guarantee
+/// that the ID we use for the name will match what is generated by the
+/// sequence used for the catalog's IDs.
+async fn create_compressed_chunk_data_table(
+    tx: &Transaction<'_>,
+    uncompressed_chunk: &Chunk,
+    chunk_schema: &str,
+    chunk_name: &str,
+) -> Result<CompressedChunk> {
+    let chunk_name = add_backfill_prefix(chunk_name);
+    let data_table_name = quote_table_name(chunk_schema, &chunk_name);
+    let parent_table_name = compressed_hypertable_name(
+        tx,
+        &uncompressed_chunk.hypertable_schema,
+        &uncompressed_chunk.hypertable_name,
+    )
+    .await?;
+
+    trace!(
+        "creating compressed chunk data table {} as a child of {}",
+        data_table_name,
+        parent_table_name
+    );
+
+    let query = format!(
+        "create table {}() inherits ({})",
+        data_table_name, parent_table_name
+    );
+
+    tx.execute(&query, &[]).await?;
+
+    Ok(CompressedChunk {
+        chunk_schema: chunk_schema.into(),
+        chunk_name,
+    })
+}
+
+/// Adds the backfill prefix `COMPRESS_TABLE_NAME_PREFIX` to the table name.
+///
+/// If adding the prefix exceeds the Postgres limit for identifiers, the table
+/// name is truncated by removing characters from the beginning instead of the
+/// end. This is done to preserve the chunk identifiers at the end of the table
+/// name, ensuring uniqueness.
+fn add_backfill_prefix(table_name: &str) -> String {
+    let table_name = if table_name.len() + COMPRESS_TABLE_NAME_PREFIX.len() >= PG_NAME_DATA_LEN {
+        &table_name[COMPRESS_TABLE_NAME_PREFIX.len()..]
+    } else {
+        table_name
+    };
+
+    format!("bf_{}", table_name)
+}
+
+/// Returns the name of the compressed hypertable associated to the given
+/// uncompressed hypertable.
+///
+/// The name is returned as "{schema}"."{name}" with both identifiers quoted.
+async fn compressed_hypertable_name(
+    tx: &Transaction<'_>,
+    uncompressed_hypertable_schema: &String,
+    uncompressed_hypertable_table: &String,
+) -> Result<String> {
+    let row = tx
+        .query_one(
+            r#"
+SELECT ch.schema_name, ch.table_name
+FROM _timescaledb_catalog.hypertable ch
+JOIN
+    _timescaledb_catalog.hypertable h ON h.compressed_hypertable_id = ch.id
+WHERE
+    h.schema_name = $1 AND h.table_name = $2
+ "#,
+            &[
+                uncompressed_hypertable_schema,
+                uncompressed_hypertable_table,
+            ],
+        )
+        .await?;
+
+    let schema_name: String = row.get("schema_name");
+    let table_name: String = row.get("table_name");
+    Ok(quote_table_name(&schema_name, &table_name))
+}
+
+/// Uses `_timescaledb_internal.create_compressed_chunk` to convert the
+/// `target_data_table` into a compressed chunk of `target_chunk`.
+///
+/// This takes care of creating the triggers, indexes and constraints missing
+/// on the data table, and updating the catalog to reflect the new compressed
+/// chunk.
+///
+/// The function requires the compression size information for the table. This
+/// information is fetched from the `source_compressed_chunk`.
+async fn create_compressed_chunk_from_data_table(
+    source_tx: &Transaction<'_>,
+    target_tx: &Transaction<'_>,
+    source_compressed_chunk: &CompressedChunk,
+    target_chunk: &Chunk,
+    target_data_table: &CompressedChunk,
+) -> Result<()> {
+    let compression_size = fetch_compression_size(source_tx, source_compressed_chunk).await?;
+
+    target_tx
+        .execute(
+            r#"
+SELECT _timescaledb_internal.create_compressed_chunk(
+    $1::TEXT::REGCLASS,
+    $2::TEXT::REGCLASS,
+    $3,$4,$5,$6,$7,$8,$9,$10)
+    "#,
+            &[
+                &target_chunk.quoted_name(),
+                &target_data_table.quoted_name(),
+                &compression_size.uncompressed_heap_size,
+                &compression_size.uncompressed_toast_size,
+                &compression_size.uncompressed_index_size,
+                &compression_size.compressed_heap_size,
+                &compression_size.compressed_toast_size,
+                &compression_size.compressed_index_size,
+                &compression_size.numrows_pre_compression,
+                &compression_size.numrows_post_compression,
+            ],
+        )
+        .await?;
+
+    Ok(())
+}
+
+/// Fetches the compression size of the given `CompressedChunk`
+async fn fetch_compression_size(
+    tx: &Transaction<'_>,
+    compressed_chunk: &CompressedChunk,
+) -> Result<CompressionSize> {
+    let row = tx
+        .query_one(
+            r#"
+SELECT
+    uncompressed_heap_size,
+    uncompressed_toast_size,
+    uncompressed_index_size,
+    compressed_heap_size,
+    compressed_toast_size,
+    compressed_index_size,
+    numrows_pre_compression,
+    numrows_post_compression
+FROM _timescaledb_catalog.compression_chunk_size s
+JOIN _timescaledb_catalog.chunk c ON c.id = s.compressed_chunk_id
+WHERE c.schema_name = $1 AND c.table_name = $2
+        "#,
+            &[&compressed_chunk.chunk_schema, &compressed_chunk.chunk_name],
+        )
+        .await?;
+
+    Ok(CompressionSize {
+        uncompressed_heap_size: row.get("uncompressed_heap_size"),
+        uncompressed_toast_size: row.get("uncompressed_toast_size"),
+        uncompressed_index_size: row.get("uncompressed_index_size"),
+        compressed_heap_size: row.get("compressed_heap_size"),
+        compressed_toast_size: row.get("compressed_toast_size"),
+        compressed_index_size: row.get("compressed_index_size"),
+        numrows_pre_compression: row.get("numrows_pre_compression"),
+        numrows_post_compression: row.get("numrows_post_compression"),
+    })
 }

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -116,4 +116,51 @@ impl Chunk {
         }
         serde_json::to_string(&dimensions_json)
     }
+
+    pub fn quoted_name(&self) -> String {
+        quote_table_name(&self.chunk_schema, &self.chunk_name)
+    }
+}
+
+pub struct CompressedChunk {
+    pub chunk_schema: String,
+    pub chunk_name: String,
+}
+
+impl CompressedChunk {
+    pub fn quoted_name(&self) -> String {
+        quote_table_name(&self.chunk_schema, &self.chunk_name)
+    }
+}
+
+pub fn quote_table_name(schema_name: &str, table_name: &str) -> String {
+    format!("{}.{}", quote_ident(schema_name), quote_ident(table_name))
+}
+
+/// `quote_ident` quotes the given value as an identifier (table, schema) safely for use in a `simple_query` call.
+/// Implementation matches that of `quote_identifier` in ruleutils.c of the `PostgreSQL` code,
+/// with `quote_all_identifiers` = true.
+pub fn quote_ident(value: &str) -> String {
+    let mut result = String::with_capacity(value.len() + 4);
+    result.push('"');
+    for c in value.chars() {
+        if c == '"' {
+            result.push(c);
+        }
+        result.push(c);
+    }
+    result.push('"');
+    result
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CompressionSize {
+    pub uncompressed_heap_size: i64,
+    pub uncompressed_toast_size: i64,
+    pub uncompressed_index_size: i64,
+    pub compressed_heap_size: i64,
+    pub compressed_toast_size: i64,
+    pub compressed_index_size: i64,
+    pub numrows_pre_compression: i64,
+    pub numrows_post_compression: i64,
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -235,4 +235,26 @@ generate_tests!(
             }),
         }
     ),
+    (
+        copy_source_has_compressed_chunk_not_present_in_target,
+        TestCase {
+            setup_sql: vec![
+                PsqlInput::Sql(SETUP_HYPERTABLE),
+                PsqlInput::Sql(ENABLE_HYPERTABLE_COMPRESSION),
+                PsqlInput::Sql(INSERT_DATA_FOR_MAY),
+                PsqlInput::Sql(COMPRESS_ONE_CHUNK),
+            ],
+            completion_time: "2023-07-01T00:00:00",
+            post_skeleton_source_sql: vec![PsqlInput::Sql(COMPRESS_ONE_CHUNK),],
+            post_skeleton_target_sql: vec![],
+            asserts: Box::new(|source: &mut DbAssert, target: &mut DbAssert| {
+                for dbassert in vec![source, target] {
+                    dbassert
+                        .has_table_count("public", "metrics", 744)
+                        .has_chunk_count("public", "metrics", 5)
+                        .has_compressed_chunk_count("public", "metrics", 2);
+                }
+            }),
+        }
+    ),
 );


### PR DESCRIPTION
When processing a chunk, the uncompressed chunk is copied first. If an associated compressed chunk exists, its data is also copied.

If the compressed chunk is not present in the target, it is created. This involves creating a child table of the compressed hypertable, copying the data from the source to the target, and then calling _timescaledb_internal.create_compressed_chunk.

The _timescaledb_internal.create_compressed_chunk function handles the insertion of the data table into the catalog and creates the necessary triggers, constraints, and indexes.

closes #12