### PR TITLE
fix: exclude pg_toast when querying triggers

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -135,7 +135,8 @@ async fn drop_invalidation_trigger(tx: &Transaction<'_>, chunk_name: &str) -> Re
             FROM pg_trigger t
             JOIN pg_class c ON t.tgrelid = c.oid
             JOIN pg_namespace n ON c.relnamespace = n.oid
-            WHERE t.tgname = 'ts_cagg_invalidation_trigger'
+            WHERE n.nspname != 'pg_toast' -- In cloud pg_toast gives permission denied
+              AND t.tgname = 'ts_cagg_invalidation_trigger'
               AND format('%I.%I', n.nspname, c.relname)::regclass = $1::text::regclass
             )",
             &[&chunk_name],


### PR DESCRIPTION
In cloud we need to exclude `pg_toast` from the query that checks if the invalidation trigger exists, otherwise we get:

```
2023-07-24T20:19:40.048599Z DEBUG src/execute.rs:126: Attempting to drop 
invalidation trigger on '"_timescaledb_internal"."_hyper_27_1458_chunk"'

Error: worker pool error

Caused by:
    0: worker execution error
    1: db error: ERROR: permission denied for schema pg_toast
    2: ERROR: permission denied for schema pg_toast
```