### PR TITLE
feat: add progress output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "human-repr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +1564,7 @@ dependencies = [
  "clap",
  "futures-lite",
  "futures-util",
+ "human-repr",
  "multimap",
  "once_cell",
  "postgres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ clap = { version = "4.2.7", default-features = false, features = ["std", "help",
 chrono = { version = "0.4.24", default-features = false, features = ["clock", "serde"] }
 futures-lite = { version = "1.13.0", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.28", default-features = false, features = ["sink"] }
+human-repr = "1.1.0"
 multimap = "0.9.0"
 rustls = { version = "0.21.1", features = ["dangerous_configuration", "tls12"], default-features = false }
 tokio = { version = "1.28.0", features = ["fs", "io-util", "macros", "rt-multi-thread", "signal", "time"], default-features = false }

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -83,7 +83,7 @@ async fn copy_uncompressed_chunk_data(
     target_chunk: &TargetChunk,
     filter: &Option<String>,
 ) -> Result<()> {
-    debug!("Copying uncompressed chunk");
+    debug!("Copying uncompressed chunk {}", source_chunk.quoted_name());
 
     let trigger_dropped = drop_invalidation_trigger(target_tx, &target_chunk.quoted_name()).await?;
 
@@ -105,6 +105,10 @@ async fn copy_uncompressed_chunk_data(
     if trigger_dropped {
         create_invalidation_trigger(target_tx, &target_chunk.quoted_name()).await?;
     }
+    debug!(
+        "Finished copying uncompressed chunk {}",
+        source_chunk.quoted_name()
+    );
     Ok(())
 }
 
@@ -196,7 +200,7 @@ async fn copy_compressed_chunk_data(
     source_chunk: &CompressedChunk,
     target_chunk: &CompressedChunk,
 ) -> Result<()> {
-    debug!("Copying compressed chunk");
+    debug!("Copying compressed chunk {}", source_chunk.quoted_name());
 
     let trigger_dropped = drop_invalidation_trigger(target_tx, &target_chunk.quoted_name()).await?;
 
@@ -213,6 +217,10 @@ async fn copy_compressed_chunk_data(
         create_invalidation_trigger(target_tx, &target_chunk.quoted_name()).await?;
     }
 
+    debug!(
+        "Finished copying compressed chunk {}",
+        source_chunk.quoted_name()
+    );
     Ok(())
 }
 

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -2,9 +2,14 @@ use crate::connect::{Source, Target};
 use crate::execute::copy_chunk;
 use crate::task::{claim_copy_task, complete_copy_task};
 use anyhow::{Context, Result};
+use human_repr::HumanDuration;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::task::JoinSet;
+use tokio::time::Instant;
 use tokio_postgres::Config;
 use tracing::trace;
+
+pub static PROCESSED_COUNT: AtomicU64 = AtomicU64::new(0);
 
 /// Spawns asyncronous tasks (workers) that wait until a `Chunk` is
 /// passed via a `Receiver`, and copy the data of the `Chunk` from the source
@@ -14,18 +19,25 @@ pub struct Pool {
     tasks: JoinSet<Result<()>>,
     source_config: Config,
     target_config: Config,
+    task_count: u64,
 }
 
 impl Pool {
     /// Create a new worker pool. Workers will each open a connection to
     /// both source and target with the given `Config`s, and processes the
     /// `Chunk`s received on the channel.
-    pub async fn new(num_workers: usize, source_config: &Config, target_config: &Config) -> Self {
+    pub async fn new(
+        num_workers: usize,
+        source_config: &Config,
+        target_config: &Config,
+        task_count: u64,
+    ) -> Self {
         let mut pool = Self {
             num_workers,
             tasks: JoinSet::new(),
             source_config: source_config.clone(),
             target_config: target_config.clone(),
+            task_count,
         };
 
         for _ in 0..pool.num_workers {
@@ -49,14 +61,16 @@ impl Pool {
     async fn add_worker(&mut self) {
         let source_config_clone = self.source_config.clone();
         let target_config_clone = self.target_config.clone();
-        self.tasks
-            .spawn(async move { worker_run(&source_config_clone, &target_config_clone).await });
+        let task_count = self.task_count;
+        self.tasks.spawn(async move {
+            worker_run(&source_config_clone, &target_config_clone, task_count).await
+        });
     }
 }
 
 /// Execution loop of a worker. It receives chunks from a channel and executes
 /// the `copy_chunk` function.
-async fn worker_run(source_config: &Config, target_config: &Config) -> Result<()> {
+async fn worker_run(source_config: &Config, target_config: &Config, task_count: u64) -> Result<()> {
     let mut source = Source::connect(source_config).await?;
     let mut target = Target::connect(target_config).await?;
 
@@ -67,10 +81,21 @@ async fn worker_run(source_config: &Config, target_config: &Config) -> Result<()
             .with_context(|| "error claiming copy task")?
         {
             Some(copy_task) => {
+                let start = Instant::now();
+
                 let source_tx = source.transaction().await?;
                 copy_chunk(&source_tx, &target_tx, &copy_task).await?;
                 complete_copy_task(&target_tx, &copy_task).await?;
                 source_tx.commit().await?;
+
+                let prev = PROCESSED_COUNT.fetch_add(1, Ordering::Relaxed);
+                println!(
+                    "[{}/{}] Copied chunk {} in {}",
+                    prev + 1,
+                    task_count,
+                    copy_task.source_chunk.quoted_name(),
+                    start.elapsed().human_duration()
+                );
             }
             None => break,
         }


### PR DESCRIPTION
```
> timescaledb-backfill stage --source postgres://postgres:1@localhost:5433 --target postgres://postgres:1@localhost:5434 --until "2023-04-06 00:00:00.00+00"
Staged 16 chunks to copy
```

```
> timescaledb-backfill copy --parallelism 8 --source postgres://postgres:1@localhost:5433 --target postgres://postgres:1@localhost:5434
Preparing to copy 16 chunks
[1/16] Copied chunk "_timescaledb_internal"."_hyper_2_33_chunk" in 7.2ms
[2/16] Copied chunk "_timescaledb_internal"."_hyper_2_32_chunk" in 3.34s
[3/16] Copied chunk "_timescaledb_internal"."_hyper_4_40_chunk" in 3.7ms
[4/16] Copied chunk "_timescaledb_internal"."_hyper_2_26_chunk" in 3.33s
[5/16] Copied chunk "_timescaledb_internal"."_hyper_2_25_chunk" in 3.32s
[6/16] Copied chunk "_timescaledb_internal"."_hyper_2_29_chunk" in 3.36s
[7/16] Copied chunk "_timescaledb_internal"."_hyper_2_31_chunk" in 3.37s
[8/16] Copied chunk "_timescaledb_internal"."_hyper_2_30_chunk" in 3.37s
[9/16] Copied chunk "_timescaledb_internal"."_hyper_4_39_chunk" in 3.5ms
[10/16] Copied chunk "_timescaledb_internal"."_hyper_2_27_chunk" in 3.38s
[11/16] Copied chunk "_timescaledb_internal"."_hyper_2_28_chunk" in 3.57s
[12/16] Copied chunk "_timescaledb_internal"."_hyper_2_20_chunk" in 242.8ms
[13/16] Copied chunk "_timescaledb_internal"."_hyper_2_23_chunk" in 995.6ms
[14/16] Copied chunk "_timescaledb_internal"."_hyper_2_24_chunk" in 1.02s
[15/16] Copied chunk "_timescaledb_internal"."_hyper_2_21_chunk" in 1.02s
[16/16] Copied chunk "_timescaledb_internal"."_hyper_2_22_chunk" in 1.03s
Copied 16 chunks in 4.55s
```

```
> timescaledb-backfill clean --target postgres://postgres:1@localhost:5434
Cleaned target
```

