### PR TITLE
Some performance improvements

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -253,7 +253,7 @@ async fn copy_chunk_from_source_to_target(
     while let Some(row) = stream.next().await {
         let row = row?;
         let row_len = row.len();
-        buf.extend(row);
+        buf.extend_from_slice(&row);
         if buf.len() + row_len > buffer_size {
             sink.send(buf.split().freeze()).await?;
         }


### PR DESCRIPTION
## fix: do not overfill copy buffer

## fix: improve copy performance

Calling `extend` with a `Bytes` results in using the `Extend<u8>`
implementation, which does a _per byte_ copy of the data. Switching to
`extend_from_slice` uses something more akin to `memcpy` to copy all
bytes which were received in one go.

This results in significantly less CPU usage. Without this change, the
output of time is:

```
45.87s user 7.94s system 74% cpu 1:12.49 total
```

With this change, it is:

```
11.51s user 6.45s system 25% cpu 1:11.62 total
```


