### PR TITLE
chore: de-flake ctrl-c tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,6 +1512,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap-reader"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f13fc301d415a8cd4529ba679720c59f07369bcff573618a6e8d5afebefb6f3"
+
+[[package]]
 name = "tempfile"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,6 +1628,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "tap-reader",
  "test-common",
  "testcontainers",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,6 @@ tracing-subscriber = { version = "0.3.17", default-features = false, features = 
 assert_cmd = "2.0.11"
 postgres = "0.19.5"
 pretty_env_logger = "0.5.0"
+tap-reader = "1.0.1"
 testcontainers = "0.14.0"
 test-common = { path = "test-common" }

--- a/test-common/src/config.rs
+++ b/test-common/src/config.rs
@@ -4,6 +4,7 @@ use std::ffi::OsString;
 pub trait TestConfig {
     fn args(&self) -> Vec<OsString>;
     fn action(&self) -> &str;
+    fn envs(&self) -> Vec<(String, String)>;
 }
 
 #[derive(Default, Clone)]
@@ -30,6 +31,10 @@ impl TestConfig for TestConfigClean {
     fn action(&self) -> &str {
         "clean"
     }
+
+    fn envs(&self) -> Vec<(String, String)> {
+        vec![]
+    }
 }
 
 #[derive(Default, Clone)]
@@ -37,6 +42,7 @@ pub struct TestConfigCopy {
     source: TestConnectionString,
     target: TestConnectionString,
     parallelism: u16,
+    envs: Vec<(String, String)>,
 }
 
 impl TestConfigCopy {
@@ -48,12 +54,20 @@ impl TestConfigCopy {
             source: source.connection_string(),
             target: target.connection_string(),
             parallelism: 8,
+            envs: vec![],
         }
     }
 
     pub fn with_parallel(&self, parallelism: u16) -> Self {
         Self {
             parallelism,
+            ..self.clone()
+        }
+    }
+
+    pub fn with_envs(&self, envs: Vec<(String, String)>) -> Self {
+        Self {
+            envs,
             ..self.clone()
         }
     }
@@ -73,6 +87,10 @@ impl TestConfig for TestConfigCopy {
 
     fn action(&self) -> &str {
         "copy"
+    }
+
+    fn envs(&self) -> Vec<(String, String)> {
+        self.envs.clone()
     }
 }
 
@@ -120,5 +138,9 @@ impl TestConfig for TestConfigStage {
 
     fn action(&self) -> &str {
         "stage"
+    }
+
+    fn envs(&self) -> Vec<(String, String)> {
+        vec![]
     }
 }

--- a/test-common/src/lib.rs
+++ b/test-common/src/lib.rs
@@ -74,6 +74,7 @@ pub fn spawn_backfill(config: impl TestConfig) -> Result<Child> {
     Command::cargo_bin("timescaledb-backfill")?
         .arg(config.action())
         .args(config.args())
+        .envs(config.envs())
         .stderr(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()


### PR DESCRIPTION
The ctrl-c tests need to send the ctrl-c signal after the workers have begun copying a chunk in order to test the correct behaviour. This was implemented with a sleep in the test code, but as we know, sleep is not reliable. And so the test was flaky.

This change uses the debug log output to determine whether a worker has begun copying a chunk, and sends the ctrl-c signal after this. Some wrangling was necessary to ensure that we still capture all of stdout.