### PR TITLE
feat: build static binary

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-unknown-linux-musl"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,10 +44,14 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v3
 
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.68.0
+          targets: x86_64-unknown-linux-musl
           components: clippy, rustfmt
 
       - name: Rust cache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ name = "timescaledb-backfill"
 version = "0.1.0"
 edition = "2021"
 
+[profile.release]
+debug = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
This switches the default target to x86_64-unknown-linux-musl, i.e. uses the musl libc in place of gnu libc. This causes cargo to emit a statically-linked binary.

There are concerns that using musl can cause performance overhead, especially for allocation-heavy multi-core workloads.

We profiled both the -gnu and -musl targets on an x86_64 platform, and found that there is a performance overhead of about 1.5x on memcpy operations when using musl libc. This derives from the fact the gnu libc leverages SIMD instructions on CPUs which support them, whereas musl libc does not. The result is slightly increased CPU usage, but does not affect the backfill speed, which is constrained by IO, not pure memory throughput.

The additional CPU usage is evident, with average CPU time using musl libc of 24.52s, compared to gnu libc's 19.52s:

musl benchmarks:

run 1: 13.84s user 10.83s system 63% cpu 38.953 total
run 2: 13.59s user 10.80s system 66% cpu 36.820 total
run 3: 13.72s user 10.78s system 62% cpu 39.240 total

glibc benchmarks:

run 1: 11.66s user 7.89s system 54% cpu 35.807 total
run 2: 11.77s user 7.78s system 50% cpu 38.787 total
run 3: 11.72s user 7.75s system 47% cpu 40.760 total

Given this tradeoff, the ability to provide a statically-linked binary seems to be worth the non-critial amount of additional CPU usage.
