### PR TITLE
fix: make sslmode=require work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ dependencies = [
  "testcontainers",
  "tokio",
  "tokio-postgres",
- "tokio-postgres-rustls",
+ "tokio-postgres-rustls 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1633,7 +1633,7 @@ dependencies = [
  "testcontainers",
  "tokio",
  "tokio-postgres",
- "tokio-postgres-rustls",
+ "tokio-postgres-rustls 0.10.0 (git+https://github.com/JamesGuthrie/tokio-postgres-rustls.git?rev=ab1c17c71fe9fa3942f5f6e871d7657a15db10ce)",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -1713,6 +1713,19 @@ name = "tokio-postgres-rustls"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5831152cb0d3f79ef5523b357319ba154795d64c7078b2daa95a803b54057f"
+dependencies = [
+ "futures",
+ "ring",
+ "rustls",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.10.0"
+source = "git+https://github.com/JamesGuthrie/tokio-postgres-rustls.git?rev=ab1c17c71fe9fa3942f5f6e871d7657a15db10ce#ab1c17c71fe9fa3942f5f6e871d7657a15db10ce"
 dependencies = [
  "futures",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde = { version = "1.0.171", features = ["derive"] }
 serde_json = "1.0.103"
 tokio = { version = "1.28.0", features = ["fs", "io-util", "macros", "rt-multi-thread", "signal", "time"], default-features = false }
 tokio-postgres = { version = "0.7.8", features = ["runtime", "with-serde_json-1", "with-chrono-0_4"], default-features = false }
-tokio-postgres-rustls = { version = "0.10.0", default-features = false }
+tokio-postgres-rustls = { version = "0.10.0", default-features = false, git = "https://github.com/JamesGuthrie/tokio-postgres-rustls.git", rev = "ab1c17c71fe9fa3942f5f6e871d7657a15db10ce" }
 tokio-util = "0.7.8"
 tracing = { version = "0.1.37", default-features = false, features = ["release_max_level_debug"] }
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["env-filter", "fmt", "json", "std"] }


### PR DESCRIPTION
There was an issue in the upstream "tokio-postgres-rustls" crate, which was using the wrong digest method to compute the SCRAM channel binding. Switching to my fork works around this issue. Once the upstream PR [1] has been merged, we can switch back to using the upstream release.

[1]: https://github.com/jbg/tokio-postgres-rustls/pull/14

Fixes: #41