### PR TITLE
fix: recompress when 'until' falls within a compressed chunk

### DIFF
--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -352,7 +352,7 @@ generate_tests!(
                 target
                     .has_table_count("public", "metrics", 120)
                     .has_chunk_count("public", "metrics", 5)
-                    .has_compressed_chunk_count("public", "metrics", 4);
+                    .has_compressed_chunk_count("public", "metrics", 5);
             }),
         }
     ),


### PR DESCRIPTION
When the 'until' parameter falls within a chunk which is compressed in
the source, we must read the uncompressed rows, and write them into an
uncompressed chunk. If the target chunk was previously compressed, it
should be safe to compress it again once we have written all rows into
it.

Fixes: https://github.com/timescale/timescaledb-backfill/issues/69