### PR TITLE
chore: remove cargo config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-target = "x86_64-unknown-linux-musl"

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -41,7 +41,7 @@ jobs:
           toolchain: 1.68.0
           targets: x86_64-unknown-linux-musl
 
-      - run: cargo build --release
+      - run: cargo build --release --target x86_64-unknown-linux-musl
 
       # By putting the executable in a tar archive, we can ensure that the executable bit remains set on the file, see: https://github.com/actions/upload-artifact#permission-loss
       - name: Prepare tar archive


### PR DESCRIPTION
The target setting in the cargo config file makes it that developers on
a different platform must provide the `--target` argument to cargo
commands in order to be able to build and test on non-linux platforms.
It was superfluous anyway, and could be configured in CI.
