### PR TITLE
fix: multiple stage runs duplicates the tasks

### DIFF
--- a/src/insert_source_chunks.sql
+++ b/src/insert_source_chunks.sql
@@ -16,3 +16,5 @@ values
 , $6
 , $7
 )
+on conflict do nothing
+returning true as inserted

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -15,3 +15,4 @@ create table __backfill.task
 );
 
 create unique index on __backfill.task (priority) where (worked is null);
+create unique index on __backfill.task (chunk_schema, chunk_name);

--- a/test-common/src/db_assert.rs
+++ b/test-common/src/db_assert.rs
@@ -256,6 +256,19 @@ impl DbAssert {
         self
     }
 
+    pub fn has_task_count(&mut self, count: i64) -> &mut Self {
+        let task_count = self._get_task_count().unwrap();
+        assert_eq!(
+            task_count,
+            count,
+            "{}task count is '{}', not '{}'",
+            self.name(),
+            task_count,
+            count
+        );
+        self
+    }
+
     pub fn job_runs_successfully<T: AsRef<str>>(
         &mut self,
         schema: T,
@@ -457,6 +470,13 @@ SELECT EXISTS (
               AND hypertable_name = $2"#,
             &[&schema, &table],
         )?;
+        Ok(row.get("count"))
+    }
+
+    fn _get_task_count(&mut self) -> Result<i64> {
+        let row = self
+            .connection()
+            .query_one("SELECT count(*) FROM __backfill.task", &[])?;
         Ok(row.get("count"))
     }
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -798,3 +798,68 @@ fn copy_task_with_deleted_source_chunk_skips_it() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn duplicated_stage_task_is_skipped() -> Result<()> {
+    let _ = pretty_env_logger::try_init();
+
+    let docker = Cli::default();
+
+    let source_container = docker.run(timescaledb(pg_version()));
+    let target_container = docker.run(timescaledb(pg_version()));
+
+    psql(&source_container, PsqlInput::Sql(SETUP_HYPERTABLE))?;
+    copy_skeleton_schema(&source_container, &target_container)?;
+    psql(
+        &source_container,
+        PsqlInput::Sql(
+            r"
+        INSERT INTO metrics(time, device_id, val)
+        VALUES
+            ('2016-01-02T00:00:00Z'::timestamptz - INTERVAL '1 month', 7, 21)",
+        ),
+    )?;
+    run_backfill(TestConfigStage::new(
+        &source_container,
+        &target_container,
+        "2016-01-02T00:00:00Z",
+    ))
+    .unwrap()
+    .assert()
+    .success()
+    .stdout(contains("Staged 1 chunks to copy"));
+
+    let mut target_dbassert = DbAssert::new(&target_container.connection_string())
+        .unwrap()
+        .with_name("target");
+
+    target_dbassert.has_task_count(1);
+
+    psql(
+        &source_container,
+        PsqlInput::Sql(
+            r"
+        INSERT INTO metrics(time, device_id, val)
+        VALUES
+            ('2016-01-02T00:00:00Z'::timestamptz - INTERVAL '1 day', 7, 21),
+            ('2016-01-02T00:00:00Z'::timestamptz - INTERVAL '2 month', 7, 21)",
+        ),
+    )?;
+
+    run_backfill(TestConfigStage::new(
+        &source_container,
+        &target_container,
+        "2016-01-02T00:00:00Z",
+    ))
+    .unwrap()
+    .assert()
+    .success()
+    .stdout(contains("Staged 2 chunks"))
+    .stdout(contains(
+        "Skipping 1 chunks that were already staged. To re-stage run the `clean` command first",
+    ));
+
+    target_dbassert.has_task_count(3);
+
+    Ok(())
+}


### PR DESCRIPTION
When running the `stage` command we were not checking for existing tasks for the same chunk and were inserting duplicates.