### PR TITLE
fix: skip dropped chunks on a hypertable with continuous aggregate

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -715,6 +715,7 @@ SELECT EXISTS (
   FROM _timescaledb_catalog.chunk
   WHERE schema_name = $1
     AND table_name = $2
+    AND dropped = false
 )
 "#;
     let exists = client


### PR DESCRIPTION
When a hypertable has a continuous aggregate on it, then dropping its chunks doesn't result in the row being removed from `_timescaledb_catalog.chunk`, instead the row remains, but the `dropped` column is set to `true`.