### PR TITLE
chore: optimise binary and symbols size

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -46,7 +46,6 @@ jobs:
       # By putting the executable in a tar archive, we can ensure that the executable bit remains set on the file, see: https://github.com/actions/upload-artifact#permission-loss
       - name: Prepare tar archive
         run: |
-          strip target/x86_64-unknown-linux-musl/release/timescaledb-backfill
           tar -C target/x86_64-unknown-linux-musl/release -czvf timescaledb-backfill-x86_64-linux.tar.gz timescaledb-backfill
 
       - name: Upload Release Artifact

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ version = "0.2.2"
 edition = "2021"
 
 [profile.release]
-debug = true
+debug = 1
+lto = true
+codegen-units = 1
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
The debug symbols make the binary much larger, so we had stripped them out, but they are instrumental in getting useful stack traces.

This change:
- reduces the amount of debug information in release builds
- enables link-time-optimization for space savings
- does not strip symbols from the final binary