### PR TITLE
feat: add refresh-caggs subcommand

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pgversion: [ 12, 13, 14, 15 ]
+        pgversion: [12, 13, 14, 15]
 
     runs-on: ubuntu-latest
     steps:
@@ -107,7 +107,7 @@ jobs:
           pg_dump --version
 
       - name: Test
-        run: cargo test
+        run: cargo test --workspace
         env:
           BF_TEST_PG_VERSION: ${{ matrix.pgversion }}
 
@@ -127,4 +127,3 @@ jobs:
       - name: Mark the job as a failure
         if: needs.changes.outputs.files == 'true' && (needs.lint.result != 'success' || needs.test.result != 'success')
         run: exit 1
-

--- a/src/caggs.rs
+++ b/src/caggs.rs
@@ -1,0 +1,208 @@
+use crate::connect::{Source, Target};
+use crate::timescale::{initialize_target_proc_schema, set_query_target_proc_schema};
+use anyhow::{Context, Result};
+use tokio_postgres::types::ToSql;
+use tokio_postgres::Client;
+
+/// Refresh the continuous aggregates in `target` based on the watermark values
+/// in `source`.
+pub(crate) async fn refresh_caggs(source: &Source, target: &Target) -> Result<()> {
+    initialize_target_proc_schema(target).await?;
+    let watermarks = get_watermarks(source).await?;
+    refresh_up_to_watermarks(target, watermarks).await?;
+    Ok(())
+}
+
+struct Watermark {
+    /// The schema that the continuous aggregate's view is in
+    user_view_schema: String,
+    /// The name of the continuous aggregate's view is in
+    user_view_name: String,
+    /// The value of the watermark in timescaledb's internal representation
+    watermark: i64,
+}
+
+/// Run `refresh_continuous_aggregate` for all watermark values in `watermarks`
+async fn refresh_up_to_watermarks(target: &Target, watermarks: Vec<Watermark>) -> Result<()> {
+    let (values_string, values) = build_values_list(&watermarks);
+    let snippet = if has_watermark_table(&target.client).await? {
+        "INNER JOIN _timescaledb_catalog.continuous_aggs_watermark w ON (c.mat_hypertable_id = w.mat_hypertable_id)"
+    } else {
+        "CROSS JOIN LATERAL _timescaledb_internal.cagg_watermark(c.mat_hypertable_id) w(watermark)"
+    };
+    let query = set_query_target_proc_schema(&format!(
+        r"
+        WITH RECURSIVE src AS (
+                SELECT * FROM {values_string} as _(user_view_schema, user_view_name, watermark)
+            ), caggs AS (
+            SELECT
+                0 as lvl
+              , c.*
+              , w.watermark as window_start
+              , src.watermark as window_end
+            FROM _timescaledb_catalog.continuous_agg c
+            LEFT OUTER JOIN src ON (c.user_view_schema = src.user_view_schema AND c.user_view_name = src.user_view_name)
+            {snippet}
+            WHERE c.parent_mat_hypertable_id is null
+            UNION ALL
+            SELECT
+                caggs.lvl + 1
+              , c.*
+              , w.watermark as window_start
+              , src.watermark as window_end
+            FROM caggs
+            INNER JOIN _timescaledb_catalog.continuous_agg c ON (caggs.mat_hypertable_id = c.parent_mat_hypertable_id)
+            LEFT OUTER JOIN src ON (c.user_view_schema = src.user_view_schema AND c.user_view_name = src.user_view_name)
+            {snippet}
+        )
+        SELECT
+              caggs.user_view_schema
+            , caggs.user_view_name
+            , CASE
+                WHEN td.column_type = 'timestamp'::regtype then @extschema@.to_timestamp_without_timezone(caggs.window_start)::text
+                WHEN td.column_type = 'timestamptz'::regtype then @extschema@.to_timestamp(caggs.window_start)::text
+                WHEN td.column_type = 'date'::regtype then @extschema@.to_date(caggs.window_start)::text
+                WHEN td.column_type in ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype) then caggs.window_start::text
+              END as window_start
+            , CASE
+                WHEN td.column_type = 'timestamp'::regtype then @extschema@.to_timestamp_without_timezone(caggs.window_end)::text
+                WHEN td.column_type = 'timestamptz'::regtype then @extschema@.to_timestamp(caggs.window_end)::text
+                WHEN td.column_type = 'date'::regtype then @extschema@.to_date(caggs.window_end)::text
+                WHEN td.column_type in ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype) then caggs.window_end::text
+              END as window_end
+            , td.column_type::text
+            FROM caggs
+            INNER JOIN LATERAL
+            (
+                SELECT column_type
+                FROM _timescaledb_catalog.dimension d
+                WHERE d.hypertable_id = caggs.mat_hypertable_id
+                ORDER BY d.id
+                limit 1
+            ) td ON (true)
+            WHERE caggs.window_start IS NOT NULL
+            AND caggs.window_end IS NOT NULL
+            AND caggs.window_start < caggs.window_end
+            ORDER BY caggs.lvl, caggs.window_start
+    "
+    ));
+    let rows = target
+        .client
+        .query(&query, &values[..])
+        .await
+        .context("unable to get detailed refresh information")?;
+    for row in rows {
+        let user_view_schema: String = row.get(0);
+        let user_view_name: String = row.get(1);
+        let window_start: String = row.get(2);
+        let window_end: String = row.get(3);
+        let column_type: String = row.get(4);
+        println!("Refreshing continuous aggregate '{user_view_schema}'.'{user_view_name}' in range [{window_start}, {window_end})");
+        target.client.execute(&format!("CALL refresh_continuous_aggregate(format('%I.%I', $1::text, $2::text)::regclass, $3::text::{column_type}, $4::text::{column_type})"), &[&user_view_schema, &user_view_name, &window_start, &window_end]).await?;
+    }
+    Ok(())
+}
+
+/// Builds a parameterized query string and parameter array for building a
+/// VALUES list of `watermarks` of arbitrary length.
+///
+/// Given watermarks:
+/// ```
+///     vec![
+///         Watermark{"foo", "bar", 1000},
+///         Watermark{"public", "baz", 2000},
+///     ]
+/// ```
+///
+/// This function will return the tuple:
+/// ```
+///     (
+///         "(VALUES ($1, $2, $3::bigint), ($4, $5, $6::bigint))",
+///         vec!["foo", "bar", 1000, "public", "baz", 2000]
+///     )
+/// ```
+///
+fn build_values_list(watermarks: &[Watermark]) -> (String, Vec<&(dyn ToSql + Sync)>) {
+    // This madness  is the recommended way to populate a VALUES list, see:
+    // https://github.com/sfackler/rust-postgres/issues/336#issuecomment-379560207
+    let mut counter = 1;
+    let mut values: Vec<&(dyn ToSql + Sync)> = Vec::new();
+    let tuples: String = watermarks
+        .iter()
+        .map(|w| {
+            values.push(&w.user_view_schema);
+            values.push(&w.user_view_name);
+            values.push(&w.watermark);
+            let s = format!(
+                r#"(${}, ${}, ${}::bigint)"#,
+                counter,
+                counter + 1,
+                counter + 2
+            );
+            counter += 3;
+            s
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let string = format!("(VALUES {tuples})");
+    (string, values)
+}
+
+/// `get_watermarks` returns a `Watermark` for every continuous aggregate in
+/// `source`.
+async fn get_watermarks(source: &Source) -> Result<Vec<Watermark>> {
+    let query = if has_watermark_table(&source.client).await? {
+        r"
+        SELECT
+           c.user_view_schema
+         , c.user_view_name
+         , w.watermark
+        FROM _timescaledb_catalog.continuous_agg c
+        INNER JOIN _timescaledb_catalog.continuous_aggs_watermark w ON (c.mat_hypertable_id = w.mat_hypertable_id);
+        "
+    } else {
+        r"
+        SELECT
+          c.user_view_schema
+        , c.user_view_name
+        , w.watermark
+        FROM _timescaledb_catalog.continuous_agg c
+        CROSS JOIN LATERAL _timescaledb_internal.cagg_watermark(c.mat_hypertable_id) w(watermark);
+        "
+    };
+    let rows = source
+        .client
+        .query(query, &[])
+        .await
+        .context("get watermarks")?;
+    Ok(rows
+        .iter()
+        .map(|r| Watermark {
+            user_view_schema: r.get(0),
+            user_view_name: r.get(1),
+            watermark: r.get(2),
+        })
+        .collect())
+}
+
+/// In TimescaleDB 2.11 the concept of the watermark table was introduced for
+/// continuous aggregates. `has_watermark_table` returns true if the watermark
+/// table is present in the specified client.
+async fn has_watermark_table(client: &Client) -> Result<bool> {
+    let row = client
+        .query_one(
+            r"
+        SELECT exists(
+            SELECT 1
+            FROM pg_class k
+            INNER JOIN pg_namespace n ON (k.relnamespace = n.oid)
+            WHERE n.nspname = '_timescaledb_catalog'
+                AND k.relname = 'continuous_aggs_watermark'
+        )
+    ",
+            &[],
+        )
+        .await
+        .context("has watermark table query")?;
+    Ok(row.get(0))
+}

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -127,7 +127,7 @@ SELECT
 }
 
 pub struct Source {
-    client: Client,
+    pub client: Client,
 }
 
 impl Source {

--- a/test-common/src/config.rs
+++ b/test-common/src/config.rs
@@ -222,3 +222,40 @@ impl TestConfig for TestConfigStage {
         vec![]
     }
 }
+
+#[derive(Default, Clone)]
+pub struct TestConfigRefreshCaggs {
+    source: TestConnectionString,
+    target: TestConnectionString,
+}
+
+impl TestConfigRefreshCaggs {
+    pub fn new<S: HasConnectionString, T: HasConnectionString>(
+        source: &'_ S,
+        target: &'_ T,
+    ) -> Self {
+        Self {
+            source: source.connection_string(),
+            target: target.connection_string(),
+        }
+    }
+}
+
+impl TestConfig for TestConfigRefreshCaggs {
+    fn args(&self) -> Vec<OsString> {
+        vec![
+            OsString::from("--source"),
+            OsString::from(self.source.as_str()),
+            OsString::from("--target"),
+            OsString::from(self.target.as_str()),
+        ]
+    }
+
+    fn action(&self) -> &str {
+        "refresh-caggs"
+    }
+
+    fn envs(&self) -> Vec<(String, String)> {
+        vec![]
+    }
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -5,6 +5,7 @@ use predicates::str::contains;
 use std::env;
 use std::ffi::OsStr;
 use std::io::{BufRead, BufReader, Read};
+use std::path::PathBuf;
 use std::process::Command;
 use strip_ansi_escapes::strip;
 use tap_reader::Tap;
@@ -1593,5 +1594,85 @@ Verifed 1 chunks in"#;
     // compare against.
     let stripped_actual_output = String::from_utf8(strip(&success.get_output().stdout))?;
     assert!(stripped_actual_output.contains(expected_diff));
+    Ok(())
+}
+
+#[test]
+fn refresh_cagg() -> Result<()> {
+    let _ = pretty_env_logger::try_init();
+    let docker = testcontainers::clients::Cli::default();
+
+    let source_container = docker.run(timescaledb(pg_version()));
+    let target_container = docker.run(timescaledb(pg_version()));
+
+    psql(
+        &source_container,
+        PsqlInput::File(PathBuf::from("tests/source_schema.sql")),
+    )?;
+    copy_skeleton_schema(&source_container, &target_container)?;
+
+    let mut source_dbassert = DbAssert::new(&source_container.connection_string())
+        .unwrap()
+        .with_name("source");
+    let mut target_dbassert = DbAssert::new(&target_container.connection_string())
+        .unwrap()
+        .with_name("target");
+
+    let watermark_cagg_t1 = 1694044800000000;
+    let watermark_cagg_t1_2 = 1695945600000000;
+    let watermark_cagg_t2 = 10;
+
+    source_dbassert.has_cagg_with_watermark("public", "caggs\"_T1", watermark_cagg_t1);
+    source_dbassert.has_cagg_with_watermark("public", "caggs_t1_2", watermark_cagg_t1_2);
+    source_dbassert.has_cagg_with_watermark("public", "caggs_t2", watermark_cagg_t2);
+    target_dbassert.has_cagg_with_watermark("public", "caggs\"_T1", watermark_cagg_t1);
+    target_dbassert.has_cagg_with_watermark("public", "caggs_t1_2", watermark_cagg_t1_2);
+    target_dbassert.has_cagg_with_watermark("public", "caggs_t2", watermark_cagg_t2);
+
+    let dual_write_query: &str = r"
+    insert into t1 values ('2023-10-06 19:27:30.024001+02', 1, 1);
+    insert into t2 values (30, 1, 1);";
+
+    psql(&source_container, PsqlInput::Sql(dual_write_query))?;
+    psql(&target_container, PsqlInput::Sql(dual_write_query))?;
+
+    psql(
+        &source_container,
+        PsqlInput::Sql(
+            r#"call refresh_continuous_aggregate('"caggs""_T1"', null, '2023-10-07 19:27:30.024001+02')"#,
+        ),
+    )?;
+    psql(
+        &source_container,
+        PsqlInput::Sql(
+            "call refresh_continuous_aggregate('caggs_t1_2', null, '2023-11-06 19:27:30.024001+02')"
+        ),
+    )?;
+    psql(
+        &source_container,
+        PsqlInput::Sql("call refresh_continuous_aggregate('caggs_t2', 0, 40)"),
+    )?;
+
+    let watermark_cagg_t1 = 1696636800000000;
+    let watermark_cagg_t1_2 = 1698537600000000;
+    let watermark_cagg_t2 = 40;
+    source_dbassert.has_cagg_with_watermark("public", "caggs\"_T1", watermark_cagg_t1);
+    source_dbassert.has_cagg_with_watermark("public", "caggs_t1_2", watermark_cagg_t1_2);
+    source_dbassert.has_cagg_with_watermark("public", "caggs_t2", watermark_cagg_t2);
+
+    run_backfill(TestConfigRefreshCaggs::new(
+        &source_container,
+        &target_container,
+    ))
+    .unwrap()
+    .assert()
+    .success()
+    .stdout(contains("Refreshing continuous aggregate 'public'.'caggs_t2' in range [10, 40)")
+        .and(contains("Refreshing continuous aggregate 'public'.'caggs\"_T1' in range [2023-09-07 00:00:00+00, 2023-10-07 00:00:00+00)"))
+        .and(contains("Refreshing continuous aggregate 'public'.'caggs_t1_2' in range [2023-09-29 00:00:00+00, 2023-10-29 00:00:00+00)")));
+
+    target_dbassert.has_cagg_with_watermark("public", "caggs\"_T1", watermark_cagg_t1);
+    target_dbassert.has_cagg_with_watermark("public", "caggs_t1_2", watermark_cagg_t1_2);
+    target_dbassert.has_cagg_with_watermark("public", "caggs_t2", watermark_cagg_t2);
     Ok(())
 }

--- a/tests/source_schema.sql
+++ b/tests/source_schema.sql
@@ -1,0 +1,61 @@
+-- create schema and load data in source
+create table t1(time timestamptz not null, key int not null, value float);
+
+select create_hypertable('t1', 'time', chunk_time_interval => interval '1 day');
+
+-- One cagg with timestamptz
+create materialized view "caggs""_T1"
+  with (timescaledb.continuous) as
+  select
+    time_bucket('1 day', "time") as day,
+    key,
+    max(value) as high
+  from t1
+  group by day, key;
+
+-- A heriarchical cagg over the previous
+create materialized view caggs_t1_2
+  with (timescaledb.continuous) as
+  select
+    time_bucket('1 month', "day") as month,
+    key,
+    max(high) as high
+  from "caggs""_T1"
+  group by month, key;
+
+insert into t1 values ('2023-09-06 19:27:30.024001+02', 1, 1);
+
+call refresh_continuous_aggregate('"caggs""_T1"', null, '2023-09-07 19:27:30.024001+02');
+call refresh_continuous_aggregate('caggs_t1_2', null, '2023-10-07 19:27:30.024001+02');
+
+create table t2(
+    time bigint not null,
+    key int not null,
+    value float
+);
+
+select create_hypertable('t2', 'time', chunk_time_interval => 10);
+
+create function latest_time_t2()
+returns bigint
+language sql
+stable
+as $$
+SELECT max(time) from t2;$$
+;
+
+select set_integer_now_func('t2', 'latest_time_t2');
+
+-- Cagg with time dimension as integer
+create materialized view caggs_t2
+  with (timescaledb.continuous) as
+  select
+    time_bucket(10, "time") as day,
+    key,
+    max(value) as high
+  from t2
+  group by day, key;
+
+insert into t2 values (1, 1, 1);
+
+call refresh_continuous_aggregate('caggs_t2', 0, 10);


### PR DESCRIPTION
The refresh-caggs subcommand can be used to bring continuous aggregates in the target database up to date with those in the source database.