### PR TITLE
fix: proc schema query support for function in multiple schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,6 +1346,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
+
+[[package]]
 name = "serde"
 version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,12 +1670,14 @@ dependencies = [
  "futures-lite",
  "futures-util",
  "human-repr",
+ "lazy_static",
  "multimap",
  "once_cell",
  "postgres",
  "predicates",
  "pretty_env_logger",
  "rustls",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,12 @@ diffy = "0.3.0"
 futures-lite = { version = "1.13.0", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.28", default-features = false, features = ["sink"] }
 human-repr = "1.1.0"
+lazy_static = "1.4.0"
 multimap = "0.9.0"
 once_cell = "1.18.0"
 predicates = "3.0.4"
 rustls = { version = "0.21.7", features = ["dangerous_configuration", "tls12"], default-features = false }
+semver = "1.0.19"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 serde_yaml = "0.9.25"

--- a/tests/source_schema.sql
+++ b/tests/source_schema.sql
@@ -36,8 +36,8 @@ create materialized view caggs_t1_3
 insert into t1 values ('2023-09-06 19:27:30.024001+02', 1, 1);
 
 call refresh_continuous_aggregate('"caggs""_T1"', null, '2023-09-07 19:27:30.024001+02');
-call refresh_continuous_aggregate('caggs_t1_2', null, '2023-09-29 02:00:00+02');
-call refresh_continuous_aggregate('caggs_t1_3', null, '2023-10-29 02:00:00+02');
+call refresh_continuous_aggregate('caggs_t1_2', null, '2023-10-30 02:00:00+02');
+call refresh_continuous_aggregate('caggs_t1_3', null, '2023-12-01 02:00:00+02');
 
 create table t2(
     time bigint not null,


### PR DESCRIPTION
The DB added support for having the functions in both the internal and functions schemas in order to maintain backwards compatibility.

This makes the query that fetches the correct schema throw an error because we expect a single row and now multiple rows are returned.