### PR TITLE
fix: verify fails with 'permission denied for schema pg_toast'

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -294,9 +294,8 @@ async fn drop_invalidation_trigger(tx: &Transaction<'_>, chunk_name: &str) -> Re
             FROM pg_trigger t
             JOIN pg_class c ON t.tgrelid = c.oid
             JOIN pg_namespace n ON c.relnamespace = n.oid
-            WHERE n.nspname != 'pg_toast' -- In cloud pg_toast gives permission denied
-              AND t.tgname = 'ts_cagg_invalidation_trigger'
-              AND format('%I.%I', n.nspname, c.relname)::regclass = $1::text::regclass
+            WHERE t.tgname = 'ts_cagg_invalidation_trigger'
+              AND format('%I.%I', n.nspname, c.relname)::text = $1::text::regclass::text
             )",
             &[&chunk_name],
         )

--- a/src/get_verify_query_select_columns.sql
+++ b/src/get_verify_query_select_columns.sql
@@ -64,7 +64,7 @@ with
                 sum_values
             )
             on (true)
-        where format('%I.%I', nspname, relname)::text::regclass = $1::text::regclass
+        where format('%I.%I', nspname, relname)::text = $1::text::regclass::text
     )
 select format('count(*) AS total_count,
     jsonb_build_object(%s)::text AS count,


### PR DESCRIPTION
A WHERE filter with `format('%I.%I', schema, table)::regclass` applied to a query which gets all relations from some table (pg_class, or _timescaledb_catalog.hypertable) is a huge footgun. It triggers checks for existence and priviliges to access the relation.

We've had to fix the same issue in different places previously, see: 243afe1cc5d18c9eb66ac6b53833b2af2bd6e96d 688681e66632dc769193b6ea08e064e2445ca732