### PR TITLE
fix: --from including extra chunks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
             files:
               - Cargo.toml
               - '**.rs'
+              - '**.sql'
               - .cargo/config.toml
               - .github/workflows/ci.yaml
 

--- a/src/find_source_chunks.sql
+++ b/src/find_source_chunks.sql
@@ -182,7 +182,7 @@ inner join lateral
     limit 1
 ) d on (true)
 inner join _timescaledb_catalog.dimension_slice ds
-on (d.id = ds.dimension_id and ds.range_start < d.upper_value and (d.lower_value is null or d.lower_value <= ds.range_end))
+on (d.id = ds.dimension_id and ds.range_start < d.upper_value and (d.lower_value is null or d.lower_value < ds.range_end))
 inner join _timescaledb_catalog.chunk_constraint cc on (ds.id = cc.dimension_slice_id)
 inner join _timescaledb_catalog.chunk c on (cc.chunk_id = c.id and h.id = c.hypertable_id)
 where c.dropped = false


### PR DESCRIPTION
 When using `from` and `until` parameters to find chunks in the source,
we added a `WHERE` statement to filter chunks based on these conditions:

- For `chunk.range_start < until`, we match chunks that start before the
  completion point. But if `range_start` of a chunk equals the `until`
  value, the chunk is ignored since `until` is exclusive and this chunk
  is outside the backfill range.

- For `from <= chunk.range_end`, we match chunks that end after or at
  the backfill start. But when `range_end` equals `from` value, this
  chunk should be ignored, because `range_end` is exclusive and the
  chunk falls outside the desired range.

Consider the chunks as [start-end) ranges:

```
[0-2)[2-4)

With `from=2`
from=2 = range_end_chunk_1=2
from=2 < range_end_chunk_2=4
```

The current statement `from <= chunk.range_end` incorrectly matches both
chunks. The first chunk doesn't have a time value inside the backfill
period because `max(time) < range_end` inside a chunk.

To fix this, we remove the equality from the second condition and match
only when `from` is less than `chunk.range_end`.
