### PR TITLE
feat: validate hypertables schemas match

### DIFF
--- a/test-common/src/db_assert.rs
+++ b/test-common/src/db_assert.rs
@@ -342,7 +342,7 @@ impl DbAssert {
             watermark,
             self._fetch_cagg_watermark(schema.as_ref(), name.as_ref())
                 .unwrap(),
-            "{}cagg '{}.{}' watermark missmatch",
+            "{}cagg '{}.{}' watermark mismatch",
             self.name(),
             schema.as_ref(),
             name.as_ref(),


### PR DESCRIPTION
If there's a mismatch between the columns of the table in source and target, an error will be triggered when copying the data, or sooner if the problematic column is the time dimension.

To prevent this kind of errors sooner, the tool is going to perform a check that the tables definitions in source match in target. This check is perform after the list of chunks is retrieved from source and before the tasks are created.

The validation consists on checking that the columns of each hypertable in source matches its names, position and data type, as its target counterpart. If a hypertable exists in source and not in target it's also considered a validation error.

closes #141 