### PR TITLE
fix: column mismatch error due to ordinal position

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -323,7 +323,6 @@ SELECT
   table_name,
   JSON_AGG(
     JSON_BUILD_OBJECT (
-      'ordinal_position', ordinal_position,
       'column_name', column_name,
       'data_type', data_type,
       'udt_schema', udt_schema,
@@ -364,7 +363,6 @@ WITH
       table_name,
       JSONB_AGG(
         JSONB_BUILD_OBJECT(
-          'ordinal_position', ordinal_position,
           'column_name', column_name,
           'data_type', data_type,
           'udt_schema', udt_schema,
@@ -394,8 +392,6 @@ SELECT
           elements ->> 'udt_name'
         ),
         ', '
-        ORDER BY
-          (elements ->> 'ordinal_position')::int
       )
     FROM
       jsonb_array_elements(source.columns) AS elements
@@ -411,8 +407,6 @@ SELECT
           elements ->> 'udt_name'
         ),
         ', '
-        ORDER BY
-          (elements ->> 'ordinal_position')::int
       )
     FROM
       jsonb_array_elements(target.columns) AS elements

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -421,6 +421,35 @@ generate_tests!(
         }
     ),
     (
+        copy_data_from_chunks_different_column_ordinal,
+        TestCase {
+            setup_sql: vec![
+                PsqlInput::Sql(SETUP_HYPERTABLE),
+                PsqlInput::Sql("ALTER TABLE public.metrics DROP COLUMN val"),
+                PsqlInput::Sql("ALTER TABLE public.metrics ADD COLUMN val FLOAT8"),
+                PsqlInput::Sql(INSERT_DATA_FOR_MAY),
+            ],
+            completion_time: "2023-06-01T00:00:00",
+            starting_time: None,
+            post_skeleton_source_sql: vec![],
+            post_skeleton_target_sql: vec![],
+            asserts: Box::new(|source: &mut DbAssert, target: &mut DbAssert| {
+                for dbassert in [source, target] {
+                    dbassert
+                        .has_table_count("public", "metrics", 744)
+                        .has_chunk_count("public", "metrics", 5);
+                }
+                let tasks = 5;
+                target.has_telemetry(vec![
+                    assert_stage_telemetry(tasks),
+                    assert_copy_telemetry(tasks),
+                    assert_verify_telemetry(tasks, 0),
+                ]);
+            }),
+            filter: None,
+        }
+    ),
+    (
         copy_data_from_chunks_with_from_flag,
         TestCase {
             setup_sql: vec![


### PR DESCRIPTION
When dropping and adding columns to a table, the ordinal position of the
columns stops being a continuous sequence of number (1,2,4), in this
example the position 3 was a dropped column, and position 4 an added
column.

If the table is dumped and restore into a new database the
ordinal position from source is not maintained, it will be a continuous
sequence (1,2,3)

When comparing the table between source and table we were including the
ordinal position of the columns into the comparison. That was causing
failures for the previously mentioned scenario.

To fix it, the ordinal position is only use to sort the columns into a
list of source and target columns, and both lists are compared.
