### PR TITLE
feat: support TS 2.17 to 2.21

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @timescale/connectors

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,15 +18,12 @@ env:
 
 jobs:
   changes:
-    runs-on: non-prod
+    runs-on: ubuntu-latest
     outputs:
       files: ${{ steps.filter.outputs.files }}
     steps:
       - name: Setup | Checkout submodules
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-          token: ${{ secrets.API_TOKEN_GITHUB }}
+        uses: actions/checkout@v4
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -44,13 +41,10 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.files == 'true' }}
 
-    strategy:
-      fail-fast: true
-
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Note: this wizardry allows git dependencies to be specified as ssh:// uris in Cargo.toml, but
       # be checked out with our ORG_AUTOMATION_TOKEN PAT. Thank god for stackoverflow.
@@ -86,13 +80,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pgversion: [13, 14, 15, 16]
-        tsversion: [2.13, 2.14]
+        pgversion: [17]
+        tsversion: ["2.17", "2.18", "2.19", "2.20", "2.21"]
 
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Note: this wizardry allows git dependencies to be specified as ssh:// uris in Cargo.toml, but
       # be checked out with our ORG_AUTOMATION_TOKEN PAT. Thank god for stackoverflow.
@@ -115,13 +109,13 @@ jobs:
 
       # This is required for the integration tests. If we move them to their
       # own action we can remove it.
-      - name: Install PG16
+      - name: Install PG17
         run: |
-          sudo apt-get --purge remove postgresql-14 postgresql-client-14 -y
+          sudo apt-get --purge remove postgresql-16 postgresql-client-16 -y
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
           sudo apt update
-          sudo apt install postgresql postgresql-client -y
+          sudo apt install postgresql-17 postgresql-client-17 -y
           psql --version
           pg_dump --version
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+TimescaleDB Backfill is a Rust-based command-line tool for migrating TimescaleDB hypertable data using the dual-write and backfill pattern. It efficiently copies data between TimescaleDB instances without requiring intermediate storage or decompressing compressed chunks.
+
+## Development Commands
+
+### Build and Test
+- `cargo build` - Build the project in debug mode
+- `cargo build --release` - Build optimized release version  
+- `cargo test` - Run all tests (unit and integration)
+- `cargo test --bins && cargo test -p test-common` - Run only unit tests (faster)
+- `make test` - Run tests with custom thread count (RUST_TEST_THREADS=4)
+- `make short-test` - Run only unit tests
+
+### Linting and Formatting
+- `cargo fmt` - Format code
+- `cargo clippy --all-targets --all-features -- -D warnings` - Lint with clippy
+- `make lint` - Run both fmt and clippy
+- `make fmt` - Format code
+- `make clippy` - Run clippy
+
+### Running the Tool
+- `cargo run --release --` - Run the tool (add arguments after --)
+- `make run` - Run via Makefile
+
+### Integration Testing
+- `make test-image` - Run integration tests against Docker image
+- Uses environment variables: `BF_TEST_PG_VERSION`, `BF_TEST_TS_VERSION`
+
+## Architecture
+
+### Core Components
+
+**Main CLI (`src/main.rs`)**: Entry point with three main subcommands:
+- `stage` - Creates copy tasks for hypertable chunks
+- `copy` - Processes tasks and copies chunks  
+- `clean` - Removes administrative schema
+
+**Key Modules**:
+- `connect.rs` - Database connection management for Source/Target
+- `execute.rs` - Core data copying logic with transaction handling
+- `task.rs` - Task management and chunk processing
+- `timescale.rs` - TimescaleDB-specific operations and version handling
+- `workers.rs` - Concurrent processing with worker pools
+- `verify.rs` - Data verification between source and target
+- `caggs.rs` - Continuous aggregates handling
+- `storage.rs` - Administrative schema management
+- `telemetry.rs` - Usage telemetry collection
+
+### Database Schema
+
+The tool creates a `__backfill` administrative schema in the target database to track:
+- Copy tasks and their status
+- Chunk metadata and processing state
+- Verification results
+- Progress tracking
+
+### Key Features
+
+**Chunk-based Processing**: Operates directly on TimescaleDB chunks for efficiency
+**Transactional Safety**: Uses transactions to ensure data consistency
+**Parallel Processing**: Worker pool for concurrent chunk processing
+**Verification**: Optional data verification between source and target
+**Telemetry**: Collects usage statistics (can be disabled)
+
+### Dependencies
+
+- PostgreSQL client libraries via `tokio-postgres`
+- Async runtime with `tokio`
+- CLI parsing with `clap`
+- Logging with `tracing`
+- Private dependencies: `telemetry-client`, `test-common`
+
+## Testing
+
+### Test Structure
+- `tests/integration/` - Integration tests requiring database setup
+- Unit tests embedded in source files
+- `test-common/` - Shared testing utilities
+- `test-manual/` - Manual testing scripts and SQL
+
+### Test Configuration
+- Supports PostgreSQL versions 15, 16, 17
+- Supports TimescaleDB versions 2.16-2.21
+- Uses testcontainers for isolated database testing
+- Environment variables control test database versions
+
+## Build Configuration
+
+### Cargo.toml Features
+- Release builds use LTO and single codegen unit for optimization
+- Debug symbols included in release builds
+- Specific Rust toolchain: 1.72.0
+
+### CI/CD
+- GitHub Actions workflow in `.github/workflows/ci.yaml`
+- Runs on multiple PostgreSQL and TimescaleDB version combinations
+- Includes linting, formatting, and comprehensive testing
+- Uses private GitHub token for private dependency access

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,8 +1977,8 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-common"
-version = "0.16.0"
-source = "git+ssh://git@github.com/timescale/test-common.git?rev=v0.16.0#9155028250437e06eabf333dce512ab197e05550"
+version = "0.20.0"
+source = "git+ssh://git@github.com/timescale/test-common.git?rev=v0.21.0#d2805f19fc61e09bb828582fd85aacb1042a91b6"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,5 +46,5 @@ pretty_env_logger = "0.5.0"
 reqwest = "0.11.22"
 tap-reader = "1.0.1"
 testcontainers = "0.14.0"
-test-common = { git = "ssh://git@github.com/timescale/test-common.git", rev = "v0.16.0"}
+test-common = { git = "ssh://git@github.com/timescale/test-common.git", rev = "v0.21.0"}
 strip-ansi-escapes = "0.2.0"

--- a/src/features.rs
+++ b/src/features.rs
@@ -8,11 +8,18 @@ use std::sync::OnceLock;
 static PER_CHUNK_COMPRESSION_SETTINGS: OnceLock<bool> = OnceLock::new();
 static STORAGE_TYPE_IN_CREATE_TABLE: OnceLock<bool> = OnceLock::new();
 static MUTATION_OF_COMPRESSED_HYPERTABLES: OnceLock<bool> = OnceLock::new();
+static NO_SEQUENCE_NUMBER_IN_COMPRESSED_HYPERTABLES: OnceLock<bool> = OnceLock::new();
+static COMPRESSION_SETTINGS_WITH_COMPRESS_RELID: OnceLock<bool> = OnceLock::new();
+static HYPERCORE_TAM: OnceLock<bool> = OnceLock::new();
 
 pub async fn initialize_features(target: &Target) -> Result<()> {
     let ts_version = &Version::parse(&fetch_tsdb_version(&target.client).await?)?;
     let pg_version = fetch_pg_version_number(&target.client).await?;
 
+    let ts_lt_222 = VersionReq::parse("<2.22.0").unwrap().matches(ts_version);
+    let ts_ge_219 = VersionReq::parse(">=2.19.0").unwrap().matches(ts_version);
+    let ts_ge_218 = VersionReq::parse(">=2.18.0").unwrap().matches(ts_version);
+    let ts_ge_217 = VersionReq::parse(">=2.17.0").unwrap().matches(ts_version);
     let ts_ge_214 = VersionReq::parse(">=2.14.0").unwrap().matches(ts_version);
     let ts_ge_211 = VersionReq::parse(">=2.11.0").unwrap().matches(ts_version);
     let pg_ge_16 = pg_version >= 160000;
@@ -29,6 +36,28 @@ pub async fn initialize_features(target: &Target) -> Result<()> {
     MUTATION_OF_COMPRESSED_HYPERTABLES
         .set(pg_ge_14 && ts_ge_211)
         .map_err(|e| anyhow!("MUTATION_OF_COMPRESSED_HYPERTABLES already set to {}", e))?;
+
+    NO_SEQUENCE_NUMBER_IN_COMPRESSED_HYPERTABLES
+        .set(ts_ge_217)
+        .map_err(|e| {
+            anyhow!(
+                "NO_SEQUENCE_NUMBER_IN_COMPRESSED_HYPERTABLES already set to {}",
+                e
+            )
+        })?;
+
+    COMPRESSION_SETTINGS_WITH_COMPRESS_RELID
+        .set(ts_ge_219)
+        .map_err(|e| {
+            anyhow!(
+                "COMPRESSION_SETTINGS_WITH_COMPRESS_RELID already set to {}",
+                e
+            )
+        })?;
+
+    HYPERCORE_TAM
+        .set(ts_ge_218 && ts_lt_222)
+        .map_err(|e| anyhow!("HYPERCORE_TAM already set to {}", e))?;
     Ok(())
 }
 
@@ -51,4 +80,23 @@ pub fn mutation_of_compressed_hypertables() -> bool {
     *MUTATION_OF_COMPRESSED_HYPERTABLES
         .get()
         .expect("STORAGE_TYPE_IN_CREATE_TABLE is not set")
+}
+
+// Supported from TS >= 2.17.0
+pub fn no_sequence_number_in_compressed_hypertables() -> bool {
+    *NO_SEQUENCE_NUMBER_IN_COMPRESSED_HYPERTABLES
+        .get()
+        .expect("NO_SEQUENCE_NUMBER_IN_COMPRESSED_HYPERTABLES is not set")
+}
+
+// Supported from TS >= 2.19.0
+pub fn compression_settings_with_compress_relid() -> bool {
+    *COMPRESSION_SETTINGS_WITH_COMPRESS_RELID
+        .get()
+        .expect("COMPRESSION_SETTINGS_WITH_COMPRESS_RELID is not set")
+}
+
+// Supported from TS >= 2.18.0 to < 2.22.0
+pub fn hypercore_tam() -> bool {
+    *HYPERCORE_TAM.get().expect("HYPERCORE_TAM is not set")
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -2,7 +2,7 @@ use crate::connect::{Source, Target};
 use crate::sql::assert_regex;
 use crate::storage::{backfill_schema_exists, init_schema};
 use crate::timescale::{set_query_source_proc_schema, Hypertable, SourceChunk, TargetChunk};
-use crate::TERM;
+use crate::{features, TERM};
 use anyhow::{bail, Result};
 use std::collections::HashSet;
 use tokio_postgres::error::SqlState;
@@ -311,11 +311,189 @@ pub async fn clean(target_config: &Config) -> Result<()> {
     Ok(())
 }
 
+// Hypercore TAM was deprecated and sunsetted in TS 2.22
+async fn validate_hypertables_and_hypercore_tam<T: GenericClient>(
+    source: &T,
+    target: &T,
+    hypertables: Vec<String>,
+) -> Result<()> {
+    let source_schema = r"
+WITH agg AS (
+SELECT
+  c.table_schema,
+  c.table_name,
+  am.amname as access_method,
+  JSON_AGG(
+    JSON_BUILD_OBJECT (
+      'column_name', c.column_name,
+      'data_type', c.data_type,
+      'udt_schema', c.udt_schema,
+      'udt_name', c.udt_name
+    )
+    ORDER BY c.ordinal_position
+  ) AS columns
+FROM
+  information_schema.columns c
+  JOIN pg_class pc ON pc.relname = c.table_name
+  JOIN pg_namespace n ON n.oid = pc.relnamespace AND n.nspname = c.table_schema
+  JOIN pg_am am ON pc.relam = am.oid
+WHERE FORMAT('%s.%s', c.table_schema, c.table_name) = ANY($1::TEXT[])
+GROUP BY 1, 2, 3
+)
+SELECT
+  JSON_AGG(
+    JSON_BUILD_OBJECT(
+      'table_schema', table_schema,
+      'table_name', table_name,
+      'access_method', access_method,
+      'columns', columns
+    )
+  )::text
+FROM agg;
+";
+
+    let Some(row) = source.query_opt(source_schema, &[&hypertables]).await? else {
+        bail!(
+            "Couldn't retrieve the source columns information from information_schema.columns for the hypertables: {}",
+            hypertables.join(",")
+        );
+    };
+
+    let source_tables_json: String = row.get(0);
+
+    // Check for hypercore access method
+    let source_tables: serde_json::Value = serde_json::from_str(&source_tables_json)?;
+    let hypercore_tables: Vec<String> = source_tables
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .filter_map(|table| {
+            if table["access_method"].as_str() == Some("hypercore") {
+                Some(format!(
+                    "{}.{}",
+                    table["table_schema"].as_str().unwrap_or(""),
+                    table["table_name"].as_str().unwrap_or("")
+                ))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if !hypercore_tables.is_empty() {
+        bail!(
+            "TimescaleDB does no longer support the hypercore table access method. Convert the following tables to heap access method before upgrading: {}",
+            hypercore_tables.join(", ")
+        );
+    }
+
+    let query = r#"
+WITH
+  target AS (
+    SELECT
+      table_schema,
+      table_name,
+      JSONB_AGG(
+        JSONB_BUILD_OBJECT(
+          'column_name', column_name,
+          'data_type', data_type,
+          'udt_schema', udt_schema,
+          'udt_name', udt_name
+        )
+        ORDER BY
+          ordinal_position
+      ) AS columns
+    FROM
+      information_schema.columns
+    WHERE
+      FORMAT('%s.%s', table_schema, table_name) = ANY ($1::TEXT[])
+    GROUP BY
+      1,
+      2
+  )
+SELECT
+  format('%s.%s', source.table_schema, source.table_name) as hypertable,
+  (
+    SELECT
+      STRING_AGG(
+        FORMAT(
+          '%s %s (%s.%s)',
+          elements ->> 'column_name',
+          elements ->> 'data_type',
+          elements ->> 'udt_schema',
+          elements ->> 'udt_name'
+        ),
+        ', '
+      )
+    FROM
+      jsonb_array_elements(source.columns) AS elements
+  ) AS source_columns,
+  (
+    SELECT
+      STRING_AGG(
+        FORMAT(
+          '%s %s (%s.%s)',
+          elements ->> 'column_name',
+          elements ->> 'data_type',
+          elements ->> 'udt_schema',
+          elements ->> 'udt_name'
+        ),
+        ', '
+      )
+    FROM
+      jsonb_array_elements(target.columns) AS elements
+  ) AS target_columns
+FROM
+  JSONB_TO_RECORDSET($2::TEXT::JSONB) source (table_schema TEXT, table_name TEXT, columns JSONB)
+  LEFT JOIN target ON (
+    target.table_schema = source.table_schema
+    AND target.table_name = source.table_name
+  )
+WHERE
+  target.columns IS NULL
+  OR target.columns != source.columns
+"#;
+    let rows = target
+        .query(query, &[&hypertables, &source_tables_json])
+        .await?;
+
+    let errors: Vec<String> = rows
+        .into_iter()
+        .map(
+            |row| match row.get::<&str, Option<String>>("target_columns") {
+                Some(target_columns) => format!(
+                    "- '{}' columns mismatch:\n    * source columns: {}\n    * target columns: {}",
+                    row.get::<&str, String>("hypertable"),
+                    row.get::<&str, String>("source_columns"),
+                    target_columns,
+                ),
+                None => format!(
+                    "- '{}' not found in target:\n    * source columns: {}",
+                    row.get::<&str, String>("hypertable"),
+                    row.get::<&str, String>("source_columns"),
+                ),
+            },
+        )
+        .collect();
+
+    if !errors.is_empty() {
+        bail!(
+            "Found issues between the source and target hypertables:\n{}",
+            errors.join("\n")
+        )
+    }
+
+    Ok(())
+}
+
 async fn validate_hypertables<T: GenericClient>(
     source: &T,
     target: &T,
     hypertables: Vec<String>,
 ) -> Result<()> {
+    if features::hypercore_tam() {
+        return validate_hypertables_and_hypercore_tam(source, target, hypertables).await;
+    }
     let source_schema = r"
 WITH agg AS (
 SELECT

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -346,7 +346,7 @@ mod test {
     use crate::telemetry::fetch_db_uuid;
     use anyhow::Result;
     use test_common::PgVersion::PG15;
-    use test_common::TsVersion::TS214;
+    use test_common::TsVersion::TS216;
     use test_common::{postgres, timescaledb, HasConnectionString};
     use testcontainers::clients::Cli;
     use tokio::task::JoinHandle;
@@ -374,7 +374,7 @@ mod test {
         let _ = pretty_env_logger::try_init();
 
         let docker = Cli::default();
-        let source_container = docker.run(timescaledb(PG15, TS214));
+        let source_container = docker.run(timescaledb(PG15, TS216));
         let mut connected = connect(&source_container).await?;
 
         let result = fetch_db_uuid(&mut connected.client).await;

--- a/tests/cloud_init.sql
+++ b/tests/cloud_init.sql
@@ -1,8 +1,43 @@
-CREATE ROLE tsdbadmin WITH LOGIN;
+CREATE ROLE tsdbadmin WITH LOGIN SUPERUSER;
 CREATE DATABASE tsdb WITH OWNER tsdbadmin;
+
+--
+-- For schema: _timescaledb_internal
+ALTER DEFAULT PRIVILEGES IN SCHEMA _timescaledb_internal GRANT ALL PRIVILEGES ON TABLES TO tsdbadmin;
+ALTER DEFAULT PRIVILEGES IN SCHEMA _timescaledb_internal GRANT ALL PRIVILEGES ON SEQUENCES TO tsdbadmin;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA _timescaledb_internal TO tsdbadmin;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA _timescaledb_internal TO tsdbadmin;
+GRANT USAGE, CREATE ON SCHEMA _timescaledb_internal TO tsdbadmin;
+
+-- For schema: _timescaledb_config
+ALTER DEFAULT PRIVILEGES IN SCHEMA _timescaledb_config GRANT ALL PRIVILEGES ON TABLES TO tsdbadmin;
+ALTER DEFAULT PRIVILEGES IN SCHEMA _timescaledb_config GRANT ALL PRIVILEGES ON SEQUENCES TO tsdbadmin;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA _timescaledb_config TO tsdbadmin;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA _timescaledb_config TO tsdbadmin;
+GRANT USAGE, CREATE ON SCHEMA _timescaledb_config TO tsdbadmin;
+
+-- For schema: _timescaledb_catalog
+ALTER DEFAULT PRIVILEGES IN SCHEMA _timescaledb_catalog GRANT ALL PRIVILEGES ON TABLES TO tsdbadmin;
+ALTER DEFAULT PRIVILEGES IN SCHEMA _timescaledb_catalog GRANT ALL PRIVILEGES ON SEQUENCES TO tsdbadmin;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA _timescaledb_catalog TO tsdbadmin;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA _timescaledb_catalog TO tsdbadmin;
+GRANT USAGE, CREATE ON SCHEMA _timescaledb_catalog TO tsdbadmin;
+
+-- For schema: _timescaledb_cache
+ALTER DEFAULT PRIVILEGES IN SCHEMA _timescaledb_cache GRANT ALL PRIVILEGES ON TABLES TO tsdbadmin;
+ALTER DEFAULT PRIVILEGES IN SCHEMA _timescaledb_cache GRANT ALL PRIVILEGES ON SEQUENCES TO tsdbadmin;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA _timescaledb_cache TO tsdbadmin;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA _timescaledb_cache TO tsdbadmin;
+GRANT USAGE, CREATE ON SCHEMA _timescaledb_cache TO tsdbadmin;
 
 \c tsdb;
 
+-- The pre_restore and post_restore function can only be successfully executed by a very highly privileged
+-- user. To ensure the database owner can also execute these functions, we have to alter them
+-- from SECURITY INVOKER to SECURITY DEFINER functions. Setting the search_path explicitly is good practice
+-- for SECURITY DEFINER functions.
+-- As this function does have high impact, we do not want anyone to be able to execute the function,
+-- but only the database owner.
 ALTER FUNCTION public.timescaledb_pre_restore() SET search_path = pg_catalog,pg_temp SECURITY DEFINER;
 ALTER FUNCTION public.timescaledb_post_restore() SET search_path = pg_catalog,pg_temp SECURITY DEFINER;
 REVOKE EXECUTE ON FUNCTION public.timescaledb_pre_restore() FROM public;
@@ -10,91 +45,68 @@ REVOKE EXECUTE ON FUNCTION public.timescaledb_post_restore() FROM public;
 GRANT EXECUTE ON FUNCTION public.timescaledb_pre_restore() TO tsdbadmin;
 GRANT EXECUTE ON FUNCTION public.timescaledb_post_restore() TO tsdbadmin;
 
-REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON ALL TABLES IN SCHEMA _timescaledb_cache FROM tsdbadmin;
-REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON ALL TABLES IN SCHEMA _timescaledb_catalog FROM tsdbadmin;
-REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON ALL TABLES IN SCHEMA _timescaledb_config FROM tsdbadmin;
--- only revoke permissions from non-chunks tables in _timescaledb_internal
+-- This fixes an issue where tsdbexplorer calls this function for all hypertables, but in TimescaleDB
+-- 2.12.0 this function was altered in a way that requires more privileges due to the LOCK acquired
+-- when the query is invoked.
 DO $$
-    BEGIN
-        IF EXISTS (
-            SELECT 1
-            FROM pg_catalog.pg_class
-            WHERE relname = 'bgw_job_stat' AND
-                    relnamespace = '_timescaledb_internal'::regnamespace::oid
-        )
-        THEN
-            REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE _timescaledb_internal.bgw_job_stat FROM tsdbadmin;
-        END IF;
-        IF EXISTS (
-            SELECT 1
-            FROM pg_catalog.pg_class
-            WHERE relname = 'bgw_policy_chunk_stats' AND
-                    relnamespace = '_timescaledb_internal'::regnamespace::oid
-        )
-        THEN
-            REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE _timescaledb_internal.bgw_policy_chunk_stats FROM tsdbadmin;
-        END IF;
-        IF EXISTS (
-            SELECT 1
-            FROM pg_catalog.pg_class
-            WHERE relname = 'hypertable_chunk_local_size' AND
-                    relnamespace = '_timescaledb_internal'::regnamespace::oid
-        )
-        THEN
-            REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE _timescaledb_internal.hypertable_chunk_local_size FROM tsdbadmin;
-        END IF;
-        IF EXISTS (
-            SELECT 1
-            FROM pg_catalog.pg_class
-            WHERE relname = 'compressed_chunk_stats' AND
-                    relnamespace = '_timescaledb_internal'::regnamespace::oid
-        )
-        THEN
-            REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE _timescaledb_internal.compressed_chunk_stats FROM tsdbadmin;
-        END IF;
-    END
+BEGIN
+  IF EXISTS (
+    SELECT
+    FROM
+      pg_extension
+    WHERE
+      extname = 'timescaledb'
+      AND extversion > '2.12.'
+  ) THEN
+    ALTER FUNCTION public.hypertable_detailed_size(regclass) SET search_path = pg_catalog,pg_temp SECURITY DEFINER;
+  END IF;
+END
 $$;
 
-REVOKE UPDATE ON ALL SEQUENCES IN SCHEMA _timescaledb_cache FROM tsdbadmin;
-REVOKE UPDATE ON ALL SEQUENCES IN SCHEMA _timescaledb_catalog FROM tsdbadmin;
-REVOKE UPDATE ON ALL SEQUENCES IN SCHEMA _timescaledb_config FROM tsdbadmin;
-
-REVOKE CREATE ON SCHEMA _timescaledb_cache FROM tsdbadmin;
-REVOKE CREATE ON SCHEMA _timescaledb_catalog FROM tsdbadmin;
-REVOKE CREATE ON SCHEMA _timescaledb_config FROM tsdbadmin;
-REVOKE CREATE ON SCHEMA _timescaledb_internal FROM tsdbadmin;
-
+DO $$
+  DECLARE
+    rolname name;
+  BEGIN
+    FOREACH rolname IN ARRAY '{tsdbadmin, tsdbadmin}'::text[]
+      LOOP
+        IF pg_catalog.to_regrole(rolname) IS NULL
+        THEN
+          RAISE NOTICE 'Creating user: %', rolname;
+          EXECUTE pg_catalog.format('CREATE USER %I', rolname);
+        END IF;
+      END LOOP;
+  END$$;
 
 -- we don't use CREATE OR REPLACE FUNCTION here, as REPLACE will keep the permissions of the original user,
 -- opening us to an attack where the less-privileged user creates a "bait" function, waiting for the extension
 -- to be created or updated and replacing the trigger function subsequently to its own version. For that reason,
 -- we also check precisely the properties of the function (owner, arguments, language) when skipping its creation.
 DO $do$
-    BEGIN
-        IF NOT EXISTS(
-            SELECT 1
-            FROM pg_catalog.pg_proc
-            WHERE pronamespace = 'public'::regnamespace::oid AND
-                    proname = 'validate_job_role' AND
-                    pg_catalog.pg_get_userbyid(proowner) = 'postgres' AND
-                    pronargs = 0 AND
-                    prorettype = 'trigger'::regtype::oid AND
-                    prolang = (SELECT oid FROM pg_catalog.pg_language WHERE lanname = 'plpgsql')
+BEGIN
+  IF NOT EXISTS(
+    SELECT 1
+    FROM pg_catalog.pg_proc
+    WHERE pronamespace = 'public'::regnamespace::oid AND
+          proname = 'validate_job_role' AND
+          pg_catalog.pg_get_userbyid(proowner) = 'postgres' AND
+          pronargs = 0 AND
+          prorettype = 'trigger'::regtype::oid AND
+          prolang = (SELECT oid FROM pg_catalog.pg_language WHERE lanname = 'plpgsql')
+    )
+    THEN
+      -- if the function exists, but not with the ownership or other properties of the desired one, complain here
+      -- We avoid CREATE FUNCTION to error out because of a duplicate, as its error message would be confusing to the user.
+      IF EXISTS(
+          SELECT 1
+          FROM pg_catalog.pg_proc
+          WHERE pronamespace = 'public'::regnamespace::oid AND
+          proname = 'validate_job_role'
         )
         THEN
-            -- if the function exists, but not with the ownership or other properties of the desired one, complain here
-            -- We avoid CREATE FUNCTION to error out because of a duplicate, as its error message would be confusing to the user.
-            IF EXISTS(
-                SELECT 1
-                FROM pg_catalog.pg_proc
-                WHERE pronamespace = 'public'::regnamespace::oid AND
-                        proname = 'validate_job_role'
-            )
-            THEN
-                RAISE EXCEPTION 'Function public.validate_job_role is already defined by the user'
-                    USING HINT='Drop the function and retry';
-            END IF;
-            CREATE FUNCTION public.validate_job_role() RETURNS TRIGGER LANGUAGE plpgsql AS $tg$
+          RAISE EXCEPTION 'Function public.validate_job_role is already defined by the user'
+            USING HINT='Drop the function and retry';
+        END IF;
+      CREATE FUNCTION public.validate_job_role() RETURNS TRIGGER LANGUAGE plpgsql AS $tg$
       DECLARE
         roleowner    name;
       BEGIN
@@ -118,174 +130,355 @@ DO $do$
           NEW.owner := current_user;
           return NEW;
         END IF;
-        IF NOT pg_catalog.pg_has_role(current_role, roleowner, 'MEMBER') THEN
+
+        -- When roleowner has capital letters, it is wrapped in quotes, eg, "testRole". This fails pg_has_role() check.
+        -- Using `roleowner::regrole` fixes the issue.
+        IF NOT pg_catalog.pg_has_role(current_role, roleowner::regrole, 'MEMBER') THEN
           RAISE EXCEPTION 'Cannot % table %.% row ID %', TG_OP, TG_TABLE_SCHEMA, TG_TABLE_NAME, NEW.id USING HINT = 'owner is not a member of the current role',
           ERRCODE = '42501';
         END IF;
         RETURN NEW;
       END
       $tg$ SET search_path = pg_catalog;
-            -- make sure the function is dropped together with the extension
-            ALTER EXTENSION timescaledb ADD FUNCTION public.validate_job_role();
-        END IF;
-    END
+    -- make sure the function is dropped together with the extension
+    ALTER EXTENSION timescaledb ADD FUNCTION public.validate_job_role();
+    END IF;
+END
 $do$;
 
-
 DO $$
-    DECLARE
-        typname text;
-    BEGIN
-        IF pg_catalog.to_regclass('_timescaledb_internal.job_errors') IS NOT NULL THEN
-            -- We need to ensure the job_id 2, which is the policy job for error retention is owned by the database owner
-            -- The job having id == 2 is hardcoded in the TimescaleDB code base:
-            -- https://github.com/timescale/timescaledb/blob/7a6101a441ca4ad02018ffddd225e7abdea4385f/sql/job_error_log_retention.sql#L60
+DECLARE
+  typname text;
+BEGIN
+  -- TimescaleDB 2.15 renamed _timescaledb_internal.job_errors => _timescaledb_internal.bgw_job_stat_history
+  IF COALESCE(pg_catalog.to_regclass('_timescaledb_internal.job_errors'),
+              pg_catalog.to_regclass('_timescaledb_internal.bgw_job_stat_history')) IS NOT NULL THEN
+    -- We need to ensure the policy job for error retention is owned by the database owner
+    -- The job having id 2 initially is hardcoded in the TimescaleDB code base:
+    -- https://github.com/timescale/timescaledb/blob/7a6101a441ca4ad02018ffddd225e7abdea4385f/sql/job_error_log_retention.sql#L60
+    -- in TimescaleDB 2.15 the job for the policy_job_error_retention has been left on id 2,
+    -- policy_job_stat_history_retention got the id 3:
+    -- https://github.com/timescale/timescaledb/commit/e298ecd532f40214a0d20a90a37b51b53aa23e91
 
-            SELECT
-                pg_catalog.format_type(atttypid, atttypmod)
-            INTO STRICT
-                typname
-            FROM
-                pg_catalog.pg_attribute
-            WHERE
-                    attrelid = '_timescaledb_config.bgw_job'::regclass
-              AND attname = 'owner';
+    SELECT
+      pg_catalog.format_type(atttypid, atttypmod)
+    INTO STRICT
+      typname
+    FROM
+      pg_catalog.pg_attribute
+    WHERE
+      attrelid = '_timescaledb_config.bgw_job'::regclass
+      AND attname = 'owner';
 
-            -- In TimescaleDB 2.10.2 the data type of the column changed. This in turn requires a different sql
-            -- statement to run depending on what datatype the column is
-            IF typname = 'regrole' THEN
-                UPDATE
-                    _timescaledb_config.bgw_job
-                SET
-                    owner = 'tsdbadmin'::regrole
-                WHERE
-                        id = 2
-                  AND owner != 'tsdbadmin'::regrole
-                  AND proc_name = 'policy_job_error_retention'
-                  -- The procedure schema changes from ts2.12.0 onwards, so we check for both
-                  -- old and new names
-                  AND proc_schema IN ('_timescaledb_internal', '_timescaledb_functions');
-            ELSE
-                UPDATE
-                    _timescaledb_config.bgw_job
-                SET
-                    owner = 'tsdbadmin'
-                WHERE
-                        id = 2
-                  AND owner != 'tsdbadmin'
-                  AND proc_name = 'policy_job_error_retention'
-                  AND proc_schema IN ('_timescaledb_internal', '_timescaledb_functions');
-            END IF;
+    -- In TimescaleDB 2.10.2 the data type of the column changed. This in turn requires a different sql
+    -- statement to run depending on what datatype the column is
+    IF typname = 'regrole' THEN
+      UPDATE
+          _timescaledb_config.bgw_job
+      SET
+        owner = 'tsdbadmin'::regrole
+      WHERE
+        -- TimescaleDB 2.15 introduced job id 3 for the policy_job_stat_history_retention.
+        id in (2, 3)
+        AND owner != 'tsdbadmin'::regrole
+        AND proc_name IN ('policy_job_error_retention', 'policy_job_stat_history_retention')
+        -- The procedure schema changes from ts2.12.0 onwards, so we check for both
+        -- old and new names
+        AND proc_schema IN ('_timescaledb_internal', '_timescaledb_functions');
+    ELSE
+      UPDATE
+          _timescaledb_config.bgw_job
+      SET
+        owner = 'tsdbadmin'
+      WHERE
+        id = 2
+        AND owner != 'tsdbadmin'
+        AND proc_name IN ('policy_job_error_retention', 'policy_job_stat_history_retention')
+        AND proc_schema IN ('_timescaledb_internal', '_timescaledb_functions');
+    END IF;
 
-            -- tsdbadmin should also be allowed to purge/clean the job errors
-            GRANT DELETE ON _timescaledb_internal.job_errors TO tsdbadmin;
-        END IF;
-    END;
+      -- tsdbadmin should also be allowed to purge/clean the job errors
+    IF pg_catalog.to_regclass('_timescaledb_internal.job_errors') IS NOT NULL THEN
+      GRANT DELETE ON _timescaledb_internal.job_errors TO tsdbadmin;
+    ELSE
+      GRANT DELETE ON _timescaledb_internal.bgw_job_stat_history TO tsdbadmin;
+    END IF;
+  END IF;
+END;
 $$;
 
 -- we need to block manually inserting or changing the owner field of the jobs timescale catalog, to avoid
 -- a job running as a superuser or a user the current_user is not a member of. Otherwise, we may get privileges
 -- escalation. Check the trigger is not disabled and is BEFORE ROW INSERT or UPDATE (tgtype controls that) one.
 DO $$
-    BEGIN
-        IF NOT EXISTS(
-            SELECT 1
-            FROM pg_catalog.pg_trigger
-            WHERE tgname = 'validate_job_role_trigger'
-              AND tgrelid = '_timescaledb_config.bgw_job'::regclass::oid
-              AND tgfoid = 'public.validate_job_role()'::regprocedure::oid
-              AND tgenabled IN ('O', 'A') AND tgtype = 23
-        )
-        THEN
-            -- see the comment at the function creation about avoiding a confusing error message
-            IF EXISTS(
-                SELECT 1 FROM pg_catalog.pg_trigger
-                WHERE tgname = 'validate_job_role_trigger'
-            )
-            THEN
-                RAISE EXCEPTION 'Trigger validate_job_role_trigger is already defined by the user'
-                    USING HINT='Drop the trigger and retry';
-            END IF;
-            CREATE TRIGGER validate_job_role_trigger
-                BEFORE INSERT OR UPDATE ON _timescaledb_config.bgw_job
-                FOR EACH ROW EXECUTE FUNCTION public.validate_job_role();
-        END IF;
-    END
+  BEGIN
+    IF NOT EXISTS(
+        SELECT 1
+        FROM pg_catalog.pg_trigger
+        WHERE tgname = 'validate_job_role_trigger'
+          AND tgrelid = '_timescaledb_config.bgw_job'::regclass::oid
+          AND tgfoid = 'public.validate_job_role()'::regprocedure::oid
+          AND tgenabled IN ('O', 'A') AND tgtype = 23
+    )
+    THEN
+      -- see the comment at the function creation about avoiding a confusing error message
+      IF EXISTS(
+        SELECT 1 FROM pg_catalog.pg_trigger
+        WHERE tgname = 'validate_job_role_trigger'
+      )
+      THEN
+        RAISE EXCEPTION 'Trigger validate_job_role_trigger is already defined by the user'
+          USING HINT='Drop the trigger and retry';
+      END IF;
+      CREATE TRIGGER validate_job_role_trigger
+        BEFORE INSERT OR UPDATE ON _timescaledb_config.bgw_job
+        FOR EACH ROW EXECUTE FUNCTION public.validate_job_role();
+    END IF;
+  END
 $$;
 
+--
 
 -- add mostly insert permissions to be able to restore a dump. We only add those for the tables that have their
 -- data dumped separately from the `CREATE EXTENSION` (the so-called extension configuration tables, see
 -- https://www.postgresql.org/docs/current/extend-extensions.html#EXTEND-EXTENSIONS-CONFIG-TABLES
 
 DO $$
-    DECLARE
-        relid name;
-    BEGIN
-        -- we need to grant insert on the extension tables (pg_restore must be able to add the data dumped previously, and
-        -- update on sequences, so that pg_restore or the user would able to use setval for sequences to fix them).
-        FOR relid in (
-            SELECT cfg.relid
-            FROM pg_catalog.pg_extension
-                     JOIN LATERAL unnest(extconfig) as cfg(relid) on true
-            WHERE extname = 'timescaledb'
-              AND (pg_catalog.pg_identify_object('pg_catalog.pg_class'::regclass::oid, cfg.relid, 0)).type = 'sequence'
-        )
-            LOOP
-                EXECUTE pg_catalog.format('GRANT UPDATE ON SEQUENCE %s TO tsdbadmin', relid::regclass::text);
-            END LOOP;
+  DECLARE
+    relid name;
+  BEGIN
+    -- we need to grant insert on the extension tables (pg_restore must be able to add the data dumped previously, and
+    -- update on sequences, so that pg_restore or the user would able to use setval for sequences to fix them).
+    FOR relid in (
+      SELECT cfg.relid
+      FROM pg_catalog.pg_extension
+             JOIN LATERAL unnest(extconfig) as cfg(relid) on true
+      WHERE extname = 'timescaledb'
+        AND (pg_catalog.pg_identify_object('pg_catalog.pg_class'::regclass::oid, cfg.relid, 0)).type = 'sequence'
+    )
+      LOOP
+        EXECUTE pg_catalog.format('GRANT UPDATE ON SEQUENCE %s TO tsdbadmin', relid::regclass::text);
+      END LOOP;
 
-        -- we only need extension configuration tables (their data is dumped separately from CREATE EXTENSION)
-        FOR relid in (
-            SELECT cfg.relid
-            FROM pg_catalog.pg_extension
-                     JOIN LATERAL pg_catalog.unnest(extconfig) as cfg(relid) on true
-            WHERE extname = 'timescaledb'
-              AND (pg_catalog.pg_identify_object('pg_catalog.pg_class'::regclass::oid, cfg.relid, 0)).type = 'table'
-        )
-            LOOP
-                EXECUTE pg_catalog.format('GRANT INSERT ON TABLE %s TO tsdbadmin', relid::regclass::text);
-                -- tsdbadmin requires update permissions on cagg migration tables (related PR timescale/timestaledb#4552)
-                IF relid::regclass::text ~ 'continuous_agg_migrate_plan(|_step)$' THEN
-                    EXECUTE pg_catalog.format('GRANT UPDATE ON TABLE %s TO tsdbadmin', relid::regclass::text);
-                END IF;
-            END LOOP;
-
-        -- The telemetry events table is intended for application data (like cli tools)
-        -- that should be included in telemetry.
-        IF EXISTS (
-            SELECT FROM pg_tables
-            WHERE schemaname = '_timescaledb_catalog'
-              AND tablename = 'telemetry_event'
-        ) THEN
-            GRANT INSERT ON TABLE _timescaledb_catalog.telemetry_event TO tsdbadmin;
+    -- we only need extension configuration tables (their data is dumped separately from CREATE EXTENSION)
+    FOR relid in (
+      SELECT cfg.relid
+      FROM pg_catalog.pg_extension
+             JOIN LATERAL pg_catalog.unnest(extconfig) as cfg(relid) on true
+      WHERE extname = 'timescaledb'
+        AND (pg_catalog.pg_identify_object('pg_catalog.pg_class'::regclass::oid, cfg.relid, 0)).type = 'table'
+    )
+      LOOP
+        EXECUTE pg_catalog.format('GRANT INSERT ON TABLE %s TO tsdbadmin', relid::regclass::text);
+        -- tsdbadmin requires update permissions on cagg migration tables (related PR https://github.com/timescale/timescaledb/pull/4552)
+        IF relid::regclass::text ~ 'continuous_agg_migrate_plan(|_step)$' THEN
+            EXECUTE pg_catalog.format('GRANT UPDATE ON TABLE %s TO tsdbadmin', relid::regclass::text);
         END IF;
+        -- tsdbadmin requires update permissions on the metadata table from 2.14 onwards (related PR https://github.com/timescale/timescaledb/pull/6554)
+        IF relid::regclass::text = '_timescaledb_catalog.metadata' THEN
+           EXECUTE pg_catalog.format('GRANT UPDATE ON TABLE %s TO tsdbadmin', relid::regclass::text);
+        END IF;
+      END LOOP;
 
-        -- We should allow the creation of new chunk tables within the _timescaledb_internal schema using pg_restore.
-        -- Although we could implement an event trigger to specifically filter chunk tables, this may be unnecessary since
-        -- the schema primarily contains _stat tables and chunks, and it's improbable that we would introduce any new stat
-        -- tables in the future. We add GRANT OPTION to allow tsdbadmin to grant create privileges TO other roles; this is
-        -- necessary, i.e. to change the continuous aggregate owner, matching owner of the job that does the referesh policy.
-        -- See https://github.com/timescale/timescaledb/issues/5745 for the bugreport that would be impossible to fix without
-        -- the GRANT OPTION.
-        GRANT CREATE ON SCHEMA _timescaledb_internal TO tsdbadmin WITH GRANT OPTION;
+    -- The telemetry events table is intended for application data (like cli tools)
+    -- that should be included in telemetry.
+    IF EXISTS (
+      SELECT FROM pg_tables
+      WHERE schemaname = '_timescaledb_catalog'
+        AND tablename = 'telemetry_event'
+    ) THEN
+      GRANT INSERT ON TABLE _timescaledb_catalog.telemetry_event TO tsdbadmin;
+    END IF;
 
-        -- Workaround for https://github.com/timescale/timescaledb/issues/5449
-        -- Long story short:
-        -- - pg_dump takes out locks on *all* extension tables
-        -- - excluding them from pg_dump does not work
-        -- - without this fix, a user gets: pg_dump: error: query failed: ERROR:  permission denied for table job_errors
-        DECLARE
-            job_table text := '_timescaledb_internal.job_errors';
-        BEGIN
-            -- This only returns TRUE if:
-            -- - grantee exists
-            -- - job_table exists
-            -- - SELECT privs are missing
-            IF NOT pg_catalog.has_table_privilege('tsdbadmin', pg_catalog.to_regclass(job_table), 'SELECT WITH GRANT OPTION')
-            THEN
-                EXECUTE format('GRANT SELECT ON %s TO tsdbadmin WITH GRANT OPTION', job_table);
-            END IF;
-        END;
-    END
+    -- We should allow the creation of new chunk tables within the _timescaledb_internal schema using pg_restore.
+    -- Although we could implement an event trigger to specifically filter chunk tables, this may be unnecessary since
+    -- the schema primarily contains _stat tables and chunks, and it's improbable that we would introduce any new stat
+    -- tables in the future. We add GRANT OPTION to allow tsdbadmin to grant create privileges TO other roles; this is
+    -- necessary, i.e. to change the continuous aggregate owner, matching owner of the job that does the referesh policy.
+    -- See https://github.com/timescale/timescaledb/issues/5745 for the bugreport that would be impossible to fix without
+    -- the GRANT OPTION.
+    GRANT CREATE ON SCHEMA _timescaledb_internal TO tsdbadmin WITH GRANT OPTION;
+
+    -- Workaround for https://github.com/timescale/timescaledb/issues/5449
+    -- Long story short:
+    -- - pg_dump takes out locks on *all* extension tables
+    -- - excluding them from pg_dump does not work
+    -- - without this fix, a user gets: pg_dump: error: query failed: ERROR:  permission denied for table job_errors
+    BEGIN
+      -- The NOT has_table_privilege only returns TRUE if:
+      -- - grantee exists (if not, it will raise an exception)
+      -- - job_table exists (otherwise, it will return NULL)
+      -- - SELECT privs are missing
+      -- 2.15 renamed job_errors => bgw_job_stat_history, we try both, since IF will not proceed when the table is not there.
+      IF NOT pg_catalog.has_table_privilege('tsdbadmin', pg_catalog.to_regclass('_timescaledb_internal.job_errors'), 'SELECT WITH GRANT OPTION')
+      THEN
+        GRANT SELECT ON _timescaledb_internal.job_errors TO tsdbadmin WITH GRANT OPTION;
+      END IF;
+      IF NOT pg_catalog.has_table_privilege('tsdbadmin', pg_catalog.to_regclass('_timescaledb_internal.bgw_job_stat_history'), 'SELECT WITH GRANT OPTION')
+      THEN
+        GRANT SELECT ON _timescaledb_internal.bgw_job_stat_history TO tsdbadmin WITH GRANT OPTION;
+      END IF;
+    END;
+  END
+$$;
+
+-- In the below SQL we explicitly set the search_path for all functions belonging
+-- to the TimescaleDB extension that are not c or internal functions.
+--
+-- public.time_bucket functions get special treatment to encourage inlining of the sql
+--
+-- The below sql should be able to be run multiple times, but it would only affect
+-- anything on its first run. This script is therefore safe to run multiple times
+-- against the same database.
+--
+-- Docker images created after 2022-02-16 will *also* contain the fix, however,
+-- we'd rather be safe and double fix this for some instances. As the script
+-- is a no-op if run multiple times, this should be fine.
+DO $dynsql$
+DECLARE
+    alter_sql text;
+BEGIN
+
+    SET local search_path to pg_catalog, pg_temp;
+
+    FOR alter_sql IN
+        SELECT
+            format(
+                $$ALTER FUNCTION %I.%I(%s) SET search_path = pg_catalog, pg_temp$$,
+                nspname,
+                proname,
+                pg_catalog.pg_get_function_identity_arguments(pp.oid)
+            )
+        FROM
+            pg_depend
+        JOIN
+            pg_extension ON (oid=refobjid)
+        JOIN
+            pg_proc pp ON (objid=pp.oid)
+        JOIN
+            pg_namespace pn ON (pronamespace=pn.oid)
+        JOIN
+            pg_language pl ON (prolang=pl.oid)
+        LEFT JOIN LATERAL (
+                SELECT * FROM unnest(proconfig) WHERE unnest LIKE 'search_path=%'
+            ) sp(search_path) ON (true)
+        WHERE
+            deptype='e'
+            AND extname='timescaledb'
+            AND extversion < '2.5.2'
+            AND lanname NOT IN ('c', 'internal')
+            AND prokind = 'f'
+            -- Only those functions/procedures that do not yet have their search_path fixed
+            AND search_path IS NULL
+            AND proname != 'time_bucket'
+        ORDER BY
+            search_path
+    LOOP
+        EXECUTE alter_sql;
+    END LOOP;
+
+    -- And for the sql time_bucket functions we prefer to *not* set the search_path to
+    -- allow inlining of these functions
+    WITH sql_time_bucket_fn AS (
+        SELECT
+            pp.oid
+        FROM
+            pg_depend
+        JOIN
+            pg_extension ON (oid=refobjid)
+        JOIN
+            pg_proc pp ON (objid=pp.oid)
+        JOIN
+            pg_namespace pn ON (pronamespace=pn.oid)
+        JOIN
+            pg_language pl ON (prolang=pl.oid)
+        WHERE
+            deptype = 'e'
+            AND extname='timescaledb'
+            AND extversion < '2.5.2'
+            AND lanname = 'sql'
+            AND proname = 'time_bucket'
+            AND prokind = 'f'
+            AND prosrc NOT LIKE '%OPERATOR(pg_catalog.%'
+    )
+    UPDATE
+        pg_proc
+    SET
+        prosrc = regexp_replace(prosrc, '([-+]{1})', ' OPERATOR(pg_catalog.\1) ', 'g')
+    FROM
+        sql_time_bucket_fn AS s
+    WHERE
+        s.oid = pg_proc.oid;
+END;
+$dynsql$;
+
+-- set cloud-specific metadata for TimescaleDB telemetry
+DO $sql$
+DECLARE
+    has_new_function_schema bool;
+    exported_uuid text;
+    uuid text;
+BEGIN
+    SELECT EXISTS
+           (SELECT 1 FROM pg_proc p
+              JOIN pg_namespace n ON p.pronamespace = n.oid
+             WHERE p.proname = 'generate_uuid'
+               AND n.nspname = '_timescaledb_functions')
+    INTO STRICT has_new_function_schema;
+
+    IF has_new_function_schema THEN
+        SELECT _timescaledb_functions.generate_uuid(), _timescaledb_functions.generate_uuid()
+        INTO STRICT exported_uuid, uuid;
+    ELSE
+        SELECT _timescaledb_internal.generate_uuid(), _timescaledb_internal.generate_uuid()
+        INTO STRICT exported_uuid, uuid;
+    END IF;
+
+    INSERT INTO _timescaledb_catalog.metadata (key, value, include_in_telemetry)
+    VALUES
+        ('forge_project_id', COALESCE(pg_catalog.current_setting('cloud.project_id', true), 'undefined'), TRUE),
+        ('forge_service_id', COALESCE(pg_catalog.current_setting('cloud.service_id', true), 'undefined'), TRUE),
+        ('forge_env', COALESCE(pg_catalog.current_setting('cloud.environment', true), 'undefined'), TRUE),
+        ('exported_uuid', exported_uuid, TRUE),
+        ('uuid', uuid, TRUE)
+    ON CONFLICT (key)
+        DO UPDATE SET
+            value = EXCLUDED.value, include_in_telemetry = EXCLUDED.include_in_telemetry;
+END;
+$sql$;
+
+DO $$
+  DECLARE
+    relid name;
+  BEGIN
+    -- we need to grant insert on the extension tables (pg_restore must be able to add the data dumped previously, and
+    -- update on sequences, so that pg_restore or the user would able to use setval for sequences to fix them).
+    FOR relid in (
+      SELECT cfg.relid
+      FROM pg_catalog.pg_extension
+             JOIN LATERAL unnest(extconfig) as cfg(relid) on true
+      WHERE extname = 'timescaledb'
+        AND (pg_catalog.pg_identify_object('pg_catalog.pg_class'::regclass::oid, cfg.relid, 0)).type = 'sequence'
+    )
+      LOOP
+        EXECUTE pg_catalog.format('GRANT UPDATE ON SEQUENCE %s TO tsdbadmin', relid::regclass::text);
+      END LOOP;
+
+    -- we only need extension configuration tables (their data is dumped separately from CREATE EXTENSION)
+    FOR relid in (
+      SELECT cfg.relid
+      FROM pg_catalog.pg_extension
+             JOIN LATERAL pg_catalog.unnest(extconfig) as cfg(relid) on true
+      WHERE extname = 'timescaledb'
+        AND (pg_catalog.pg_identify_object('pg_catalog.pg_class'::regclass::oid, cfg.relid, 0)).type = 'table'
+    )
+      LOOP
+        EXECUTE pg_catalog.format('GRANT INSERT ON TABLE %s TO tsdbadmin', relid::regclass::text);
+      END LOOP;
+
+    -- we need to allow new chunk tables to be created by pg_restore in the _timescaledb_internal. We could also
+    -- create an even trigger to filter only chunk tables, but there are no only stat objects in this schema, and
+    -- it is unlikely we would create any new ones.
+    GRANT CREATE ON SCHEMA _timescaledb_internal TO tsdbadmin;
+  END
 $$;


### PR DESCRIPTION
  - For TS >= 2.17 create the indexes using the min/max values of the
  order by setting instead of the sequence number since it was removed.
- For TS >= 2.19 match the per chunk compression settings of the source
  chunk with `compress_relid` instead of `relid`.
- For TS >= 2.18 < 2.22 throw an error if the table access method is set
  to Hypercore. The feature was always an experiment and was deprecated.
- Update tests that relied on dropped chunks on hypertable with CAGGs to
  be marked as dropped instead of deleted. Now chunks are deleted unless
  the CAGG is building.
