### PR TITLE
fix: panic when compression stats have NULL row counts

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1068,8 +1068,13 @@ SELECT
     compressed_heap_size,
     compressed_toast_size,
     compressed_index_size,
-    numrows_pre_compression,
-    numrows_post_compression
+    -- The numrows_{pre,post}_compression columns were introduced
+    -- in TimescaleDB 2.0. The upgrade path does not populate default
+    -- values for older installations.
+    -- Ensure 0 is returned instead of NULL to avoid handling Option<>
+    -- in the struct.
+    COALESCE(numrows_pre_compression, 0) AS numrows_pre_compression,
+    COALESCE(numrows_post_compression, 0) AS numrows_post_compression
 FROM _timescaledb_catalog.compression_chunk_size s
 JOIN _timescaledb_catalog.chunk c ON c.id = s.compressed_chunk_id
 WHERE c.schema_name = $1 AND c.table_name = $2


### PR DESCRIPTION
Handle NULL values in numrows_pre_compression and numrows_post_compression columns from _timescaledb_catalog.compression_chunk_size table.

**Root Cause:**
TimescaleDB upgrade path from 1.x to 2.x fails to update compression statistics for existing compressed chunks. While these columns are nullable by design in the TimescaleDB schema, the backfill tool assumed they were always populated and used row.get() which panics on NULL values.

**Issue Reproduction:**
1. Create compressed chunks in TimescaleDB 1.7.5
2. Upgrade extension to 2.x (e.g., 2.5.0)
3. Run backfill tool - causes panic when accessing NULL statistics

**Error Details:**
- Panic location: src/execute.rs:1088-1089 in fetch_compression_size()
- Error: "error deserializing column 6: a Postgres value was NULL"
- Affected function: Processing compressed chunks during copy operations

For more details, refer https://github.com/timescale/Support-Dev-Collab/issues/3201#issuecomment-3217934656