### PR TITLE
fix: chunk_create during copy causes lock contention

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -110,7 +110,7 @@ SELECT
     )",
                 )
                 .await?;
-            let conninfo: String = match rows.get(0) {
+            let conninfo: String = match rows.first() {
                 Some(SimpleQueryMessage::Row(row)) => row
                     .get(0)
                     .map_or_else(String::new, std::borrow::ToOwned::to_owned),


### PR DESCRIPTION
Reported by https://iobeam.slack.com/archives/C08G2EX0L4C/p1757303548665179

Solution: move target chunk creation from copy workers to staging phase

This ensures target chunks exist at staging time rather than processing time, providing cleaner separation of concerns between staging and execution phases.

Before this fix, `create_chunk` is blocked by the COPY or another `create_chunk` for the same hypertable.
```
waiting_pid | waiting_user |                waiting_query                | blocking_pid | blocking_user |                                  blocking_query                                  |    wait_time
-------------+--------------+---------------------------------------------+--------------+---------------+----------------------------------------------------------------------------------+-----------------
     1958250 | tsdbadmin    | SELECT _timescaledb_functions.create_chunk(+|      1958248 | tsdbadmin     | COPY "_timescaledb_internal"."_hyper_1_87_chunk" FROM STDIN WITH (FORMAT BINARY) | 00:01:03.262236
             |              |             $1::text::regclass,            +|              |               |                                                                                  |
             |              |             slices => $2::TEXT::JSONB)      |              |               |                                                                                  |
     1958247 | tsdbadmin    | SELECT _timescaledb_functions.create_chunk(+|      1958248 | tsdbadmin     | COPY "_timescaledb_internal"."_hyper_1_87_chunk" FROM STDIN WITH (FORMAT BINARY) | 00:00:35.428813
             |              |             $1::text::regclass,            +|              |               |                                                                                  |
             |              |             slices => $2::TEXT::JSONB)      |              |               |                                                                                  |
     1958247 | tsdbadmin    | SELECT _timescaledb_functions.create_chunk(+|      1958250 | tsdbadmin     | SELECT _timescaledb_functions.create_chunk(                                     +| 00:00:35.428813
             |              |             $1::text::regclass,            +|              |               |             $1::text::regclass,                                                 +|
             |              |             slices => $2::TEXT::JSONB)      |              |               |             slices => $2::TEXT::JSONB)                                           |
(3 rows)
```

Regardless of the parallelism flag, copy is always serialised because of the lock contention.

```
 pid   | datid | datname |  relid  |  command  | type | bytes_processed | bytes_total | tuples_processed | tuples_excluded | tuples_skipped
---------+-------+---------+---------+-----------+------+-----------------+-------------+------------------+-----------------+----------------
 | 1958248 | 16476 | tsdb    | 1687770 | COPY FROM | PIPE |        22020913 |           0 |           274000 |               0 |              0
```

After applying this fix, there is no blocking query and the number of concurrent COPY is equal to the `--parallelism`  flag.

```
relid                   |   pid   | datid | datname |  relid  |  command  | type | bytes_processed | bytes_total | tuples_processed | tuples_excluded | tuples_skipped
------------------------------------------+---------+-------+---------+---------+-----------+------+-----------------+-------------+------------------+-----------------+----------------
 _timescaledb_internal._hyper_1_105_chunk | 1960529 | 16476 | tsdb    | 1687835 | COPY FROM | PIPE |        34604181 |           0 |           431000 |               0 |              0
 _timescaledb_internal._hyper_1_107_chunk | 1960532 | 16476 | tsdb    | 1687855 | COPY FROM | PIPE |        15729044 |           0 |           195000 |               0 |              0
 _timescaledb_internal._hyper_1_106_chunk | 1960531 | 16476 | tsdb    | 1687845 | COPY FROM | PIPE |        26215443 |           0 |           326000 |               0 |              0
(3 rows)
```

Please note that the lock contention happens only on regular chunk creation not the compressed one.
