### PR TITLE
feat: support TimescaleDB 2.29 catalog changes (+ vendor test-common)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,9 +81,14 @@ jobs:
       fail-fast: false
       matrix:
         pgversion: [17]
-        tsversion: ["2.17", "2.18", "2.19", "2.20", "2.21", "2.22"]
+        tsversion: ["2.17", "2.18", "2.19", "2.20", "2.21", "2.22", "2.23", "2.24", "2.25", "2.26", "2.27", "2.28", "nightly"]
 
     runs-on: ubuntu-latest
+    # 2.17-2.22 are fully green and gate merges. Newer releases and the nightly
+    # (2.29) build are exercised but non-blocking: they surface regressions in
+    # CI without failing the gate while their remaining test-harness gaps (e.g.
+    # the cagg invalidation-log assertion on 2.28+) are worked through.
+    continue-on-error: ${{ !contains(fromJSON('["2.17", "2.18", "2.19", "2.20", "2.21", "2.22"]'), matrix.tsversion) }}
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,7 +1989,6 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test-common"
 version = "0.22.0"
-source = "git+ssh://git@github.com/timescale/test-common.git?rev=v0.22.0#55719c07bb5ebc83259ad3ca5ad37866af463c26"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "timescaledb-backfill"
 version = "0.13.0"
 edition = "2021"
 
+[workspace]
+members = ["test-common"]
+
 [profile.release]
 debug = 1
 lto = true
@@ -46,5 +49,5 @@ pretty_env_logger = "0.5.0"
 reqwest = "0.11.22"
 tap-reader = "1.0.1"
 testcontainers = "0.14.0"
-test-common = { git = "ssh://git@github.com/timescale/test-common.git", rev = "v0.22.0"}
+test-common = { path = "test-common" }
 strip-ansi-escapes = "0.2.0"

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -243,15 +243,20 @@ async fn chunk_status_is_partial(
     target_chunk: &TargetChunk,
 ) -> Result<bool> {
     // Note: status is a bitfield, the 4th bit indicates whether the chunk is partially compressed
-    let row = target_tx
-        .query_one(
-            r"
+    let query = if features::chunk_catalog_uses_relid() {
+        r"
+        SELECT (status & 8)::bool as is_partial
+        FROM _timescaledb_catalog.chunk
+        WHERE relid = to_regclass(format('%I.%I', $1::text, $2::text))"
+    } else {
+        r"
         SELECT (status & 8)::bool as is_partial
         FROM _timescaledb_catalog.chunk
         WHERE schema_name = $1
-          AND table_name = $2",
-            &[&target_chunk.schema, &target_chunk.table],
-        )
+          AND table_name = $2"
+    };
+    let row = target_tx
+        .query_one(query, &[&target_chunk.schema, &target_chunk.table])
         .await?;
     Ok(row.get("is_partial"))
 }
@@ -388,23 +393,31 @@ async fn drop_invalidation_trigger(tx: &Transaction<'_>, chunk_name: &str) -> Re
 
 async fn create_invalidation_trigger(tx: &Transaction<'_>, chunk_name: &str) -> Result<()> {
     debug!("Creating invalidation trigger on '{chunk_name}'");
-    let hypertable_id: i32 = tx
-        .query_one(
-            r"
+    // Note: In the pre-relid catalog there is non-obvious stuff going on here.
+    // The ::text::regclass::text cast dance reformats the relation name to the
+    // database's canonical format. We _explicitly avoid_ casting the left hand
+    // side to regclass, because the _timescaledb_catalog.chunk table contains
+    // entries which refer to non-existent relations. This only happens when the
+    // hypertable has a continuous aggregate on it, and the chunk was dropped.
+    // Casting the non-existent relation to regclass throws an error.
+    //
+    // In the relid catalog (TS >= 2.29) dropped chunks are removed from the
+    // catalog and `relid` is never null, so we can match on it directly.
+    let query = if features::chunk_catalog_uses_relid() {
+        r"
         SELECT hypertable_id
         FROM _timescaledb_catalog.chunk
-        -- Note: There is non-obvious stuff going on here.
-        -- The ::text::regclass::text cast dance reformats the relation name to
-        -- the database's canonical format. We _explicitly avoid_ casting the
-        -- left hand side to regclass, because the _timescaledb_catalog.chunk
-        -- table contains entries which refer to non-existent relations. This
-        -- only happens when the hypertable has a continuous aggregate on it,
-        -- and the chunk was dropped.
-        -- Casting the non-existent relation to regclass throws an error.
+        WHERE relid = $1::text::regclass
+    "
+    } else {
+        r"
+        SELECT hypertable_id
+        FROM _timescaledb_catalog.chunk
         WHERE format('%I.%I', schema_name, table_name)::text = $1::text::regclass::text
-    ",
-            &[&chunk_name],
-        )
+    "
+    };
+    let hypertable_id: i32 = tx
+        .query_one(query, &[&chunk_name])
         .await?
         .get("hypertable_id");
 
@@ -583,9 +596,23 @@ pub async fn get_compressed_chunk(
     source_tx: &Transaction<'_>,
     chunk: &Chunk,
 ) -> Result<Option<SourceCompressedChunk>> {
-    let row = source_tx
-        .query_opt(
-            r#"
+    // In the relid catalog (TS >= 2.29) compressed chunks are no longer chunk
+    // rows. The compressed relation for a chunk is found through
+    // `compression_settings.compress_relid` (only present for compressed
+    // chunks, so an uncompressed chunk yields no row).
+    let query = if features::chunk_catalog_uses_relid() {
+        r#"
+    SELECT
+      n.nspname AS schema_name
+    , cl.relname AS table_name
+    FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = ch.relid
+    JOIN pg_class cl ON cl.oid = cs.compress_relid
+    JOIN pg_namespace n ON n.oid = cl.relnamespace
+    WHERE ch.relid = to_regclass(format('%I.%I', $1::text, $2::text))
+    "#
+    } else {
+        r#"
     SELECT
       cch.schema_name
     , cch.table_name
@@ -593,9 +620,10 @@ pub async fn get_compressed_chunk(
     JOIN _timescaledb_catalog.chunk cch ON ch.compressed_chunk_id = cch.id
     WHERE ch.schema_name = $1
       AND ch.table_name = $2
-    "#,
-            &[&chunk.schema, &chunk.table],
-        )
+    "#
+    };
+    let row = source_tx
+        .query_opt(query, &[&chunk.schema, &chunk.table])
         .await?;
     Ok(row.map(|r| SourceCompressedChunk {
         schema: r.get("schema_name"),
@@ -812,6 +840,17 @@ async fn create_compressed_chunk_index(
         .await;
     }
 
+    // Newer TimescaleDB (~2.28) stores the compressed sparse-index metadata in
+    // `_ts_meta_v2_first_<col>` / `_ts_meta_v2_last_<col>` columns (named after
+    // the orderby column) and indexes those, instead of the older
+    // `_ts_meta_min_<n>` / `_ts_meta_max_<n>` columns (indexed by position).
+    // Some versions keep both column sets, so we detect the v2 columns on the
+    // data table (a copy of the source compressed chunk) rather than gate on a
+    // version, and prefer them to match what TimescaleDB itself builds.
+    let use_v2_metadata = compressed_chunk_uses_v2_metadata(target_tx, qualified_data_table_name)
+        .await
+        .context("failed to detect compressed chunk metadata format")?;
+
     let mut index_columns: Vec<String> = compression_settings
         .segmentby
         .clone()
@@ -819,8 +858,8 @@ async fn create_compressed_chunk_index(
         .map(|c| quote_ident(c))
         .collect();
 
-    // Add min/max columns for orderby settings
-    for (i, _) in compression_settings.orderby.iter().enumerate() {
+    // Add the metadata columns for the orderby settings
+    for (i, orderby_column) in compression_settings.orderby.iter().enumerate() {
         let column_index = i + 1; // 1-based indexing as in C code
         let order_by = if compression_settings.orderby_desc[i] {
             // DESC ordering
@@ -841,10 +880,19 @@ async fn create_compressed_chunk_index(
                 "ASC"
             }
         };
-        let min_column = quote_ident(&format!("_ts_meta_min_{}", column_index));
-        let max_column = quote_ident(&format!("_ts_meta_max_{}", column_index));
-        index_columns.push(format!("{min_column} {order_by}"));
-        index_columns.push(format!("{max_column} {order_by}"));
+        let (first_column, last_column) = if use_v2_metadata {
+            (
+                quote_ident(&format!("_ts_meta_v2_first_{orderby_column}")),
+                quote_ident(&format!("_ts_meta_v2_last_{orderby_column}")),
+            )
+        } else {
+            (
+                quote_ident(&format!("_ts_meta_min_{column_index}")),
+                quote_ident(&format!("_ts_meta_max_{column_index}")),
+            )
+        };
+        index_columns.push(format!("{first_column} {order_by}"));
+        index_columns.push(format!("{last_column} {order_by}"));
     }
 
     let quoted_index_columns_list: String = index_columns
@@ -860,6 +908,28 @@ async fn create_compressed_chunk_index(
         .await
         .with_context(|| "failed to create compress chunk index")?;
     Ok(())
+}
+
+/// Detects whether a compressed chunk data table uses the v2 sparse-index
+/// metadata columns (`_ts_meta_v2_first_<col>` / `_ts_meta_v2_last_<col>`).
+async fn compressed_chunk_uses_v2_metadata(
+    tx: &Transaction<'_>,
+    qualified_data_table_name: &str,
+) -> Result<bool> {
+    let row = tx
+        .query_one(
+            r"
+            SELECT EXISTS (
+                SELECT 1
+                FROM pg_attribute
+                WHERE attrelid = $1::text::regclass
+                  AND attname ~ '^_ts_meta_v2_first_'
+                  AND NOT attisdropped
+            )",
+            &[&qualified_data_table_name],
+        )
+        .await?;
+    Ok(row.get(0))
 }
 
 async fn fetch_compressed_chunk_compression_settings(
@@ -910,11 +980,21 @@ struct CompressionSettings {
 
 impl From<Row> for CompressionSettings {
     fn from(row: Row) -> Self {
+        // In the relid catalog (TS >= 2.29) the hypertable-level
+        // `compression_settings` row only stores explicitly-configured values,
+        // leaving defaulted columns (e.g. the default time `orderby`) NULL. The
+        // per-chunk rows still materialize them. Treat NULL as empty.
+        fn col(row: &Row, name: &str) -> Vec<String> {
+            row.get::<_, Option<Vec<String>>>(name).unwrap_or_default()
+        }
+        fn flags(row: &Row, name: &str) -> Vec<bool> {
+            row.get::<_, Option<Vec<bool>>>(name).unwrap_or_default()
+        }
         CompressionSettings {
-            segmentby: row.get("segmentby"),
-            orderby: row.get("orderby"),
-            orderby_desc: row.get("orderby_desc"),
-            orderby_nullsfirst: row.get("orderby_nullsfirst"),
+            segmentby: col(&row, "segmentby"),
+            orderby: col(&row, "orderby"),
+            orderby_desc: flags(&row, "orderby_desc"),
+            orderby_nullsfirst: flags(&row, "orderby_nullsfirst"),
         }
     }
 }
@@ -943,7 +1023,22 @@ async fn validate_and_fetch_compression_settings(
     );
     let source_settings =
         fetch_compressed_chunk_compression_settings(source_tx, source_chunk_name).await?;
-    if source_settings != target_settings {
+
+    // In the relid catalog (TS >= 2.29) the hypertable-level settings omit a
+    // defaulted `orderby`, while the source chunk carries the materialized
+    // settings. Consider them compatible when the segment-by columns match and
+    // the target either shares the same explicit `orderby` or relies on the
+    // default (empty), which matches the source chunk's materialized default.
+    let compatible = if features::chunk_catalog_uses_relid() {
+        source_settings.segmentby == target_settings.segmentby
+            && (target_settings.orderby.is_empty()
+                || (source_settings.orderby == target_settings.orderby
+                    && source_settings.orderby_desc == target_settings.orderby_desc
+                    && source_settings.orderby_nullsfirst == target_settings.orderby_nullsfirst))
+    } else {
+        source_settings == target_settings
+    };
+    if !compatible {
         bail!(
             r"Compression settings mismatch.
 
@@ -962,7 +1057,15 @@ backfilled, you can change the settings back and restart the compression jobs.
         );
     }
 
-    Ok(target_settings)
+    // The compressed chunk data table (and its index) must reflect the
+    // materialized layout of the actual compressed data. Pre-2.29 the hypertable
+    // settings already were materialized; in the relid catalog we must use the
+    // source chunk's settings so a defaulted `orderby` is not lost.
+    if features::chunk_catalog_uses_relid() {
+        Ok(source_settings)
+    } else {
+        Ok(target_settings)
+    }
 }
 
 /// Adds the backfill prefix `COMPRESS_TABLE_NAME_PREFIX` to the table name.
@@ -1088,9 +1191,17 @@ async fn fetch_compression_size(
     tx: &Transaction<'_>,
     compressed_chunk: &SourceCompressedChunk,
 ) -> Result<CompressionSize> {
-    let row = tx
-        .query_one(
-            r#"
+    // The numrows_{pre,post}_compression columns were introduced in TimescaleDB
+    // 2.0. The upgrade path does not populate default values for older
+    // installations. Ensure 0 is returned instead of NULL to avoid handling
+    // Option<> in the struct.
+    //
+    // In the relid catalog (TS >= 2.29) `compression_chunk_size` is keyed by the
+    // uncompressed chunk's `chunk_id` (the `compressed_chunk_id` column is dead),
+    // so we reach it from the compressed relation through
+    // `compression_settings.compress_relid`.
+    let query = if features::chunk_catalog_uses_relid() {
+        r#"
 SELECT
     uncompressed_heap_size,
     uncompressed_toast_size,
@@ -1098,19 +1209,31 @@ SELECT
     compressed_heap_size,
     compressed_toast_size,
     compressed_index_size,
-    -- The numrows_{pre,post}_compression columns were introduced
-    -- in TimescaleDB 2.0. The upgrade path does not populate default
-    -- values for older installations.
-    -- Ensure 0 is returned instead of NULL to avoid handling Option<>
-    -- in the struct.
+    COALESCE(numrows_pre_compression, 0) AS numrows_pre_compression,
+    COALESCE(numrows_post_compression, 0) AS numrows_post_compression
+FROM _timescaledb_catalog.compression_chunk_size s
+JOIN _timescaledb_catalog.chunk c ON c.id = s.chunk_id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = c.relid
+WHERE cs.compress_relid = to_regclass(format('%I.%I', $1::text, $2::text))
+        "#
+    } else {
+        r#"
+SELECT
+    uncompressed_heap_size,
+    uncompressed_toast_size,
+    uncompressed_index_size,
+    compressed_heap_size,
+    compressed_toast_size,
+    compressed_index_size,
     COALESCE(numrows_pre_compression, 0) AS numrows_pre_compression,
     COALESCE(numrows_post_compression, 0) AS numrows_post_compression
 FROM _timescaledb_catalog.compression_chunk_size s
 JOIN _timescaledb_catalog.chunk c ON c.id = s.compressed_chunk_id
 WHERE c.schema_name = $1 AND c.table_name = $2
-        "#,
-            &[&compressed_chunk.schema, &compressed_chunk.table],
-        )
+        "#
+    };
+    let row = tx
+        .query_one(query, &[&compressed_chunk.schema, &compressed_chunk.table])
         .await?;
 
     Ok(CompressionSize {
@@ -1129,17 +1252,31 @@ pub async fn chunk_exists<T>(client: &T, chunk: &Chunk) -> Result<bool>
 where
     T: GenericClient,
 {
-    let query: &str = r#"
+    // In the relid catalog (TS >= 2.29) the relation is matched by `relid`;
+    // `to_regclass` yields NULL for a non-existent relation, so the comparison
+    // is simply never true. The `dropped` column (present before ~TS 2.26) is
+    // gated independently.
+    let predicate = if features::chunk_catalog_uses_relid() {
+        "relid = to_regclass(format('%I.%I', $1::text, $2::text))"
+    } else {
+        "schema_name = $1 AND table_name = $2"
+    };
+    let dropped_filter = if features::chunk_has_dropped_column() {
+        " AND dropped = false"
+    } else {
+        ""
+    };
+    let query = format!(
+        r#"
 SELECT EXISTS (
   SELECT 1
   FROM _timescaledb_catalog.chunk
-  WHERE schema_name = $1
-    AND table_name = $2
-    AND dropped = false
+  WHERE {predicate}{dropped_filter}
 )
-"#;
+"#
+    );
     let exists = client
-        .query_one(query, &[&chunk.schema, &chunk.table])
+        .query_one(&query, &[&chunk.schema, &chunk.table])
         .await?;
     Ok(exists.get(0))
 }

--- a/src/features.rs
+++ b/src/features.rs
@@ -11,10 +11,45 @@ static MUTATION_OF_COMPRESSED_HYPERTABLES: OnceLock<bool> = OnceLock::new();
 static NO_SEQUENCE_NUMBER_IN_COMPRESSED_HYPERTABLES: OnceLock<bool> = OnceLock::new();
 static COMPRESSION_SETTINGS_WITH_COMPRESS_RELID: OnceLock<bool> = OnceLock::new();
 static HYPERCORE_TAM: OnceLock<bool> = OnceLock::new();
+static CHUNK_CATALOG_USES_RELID: OnceLock<bool> = OnceLock::new();
+static CHUNK_HAS_DROPPED_COLUMN: OnceLock<bool> = OnceLock::new();
+
+/// Detects the shape of `_timescaledb_catalog.chunk`. Two independent columns
+/// changed across the supported range, at different versions, so we detect them
+/// directly instead of hard-coding version cut-offs:
+/// - `dropped` was removed around TS 2.26 (dropped chunks are no longer kept as
+///   catalog tombstones)
+/// - `schema_name`/`table_name`/`compressed_chunk_id` were replaced by `relid`
+///   in TS 2.29
+async fn fetch_chunk_catalog_columns(target: &Target) -> Result<(bool, bool)> {
+    let row = target
+        .client
+        .query_one(
+            r"
+            SELECT
+                bool_or(column_name = 'relid')   AS has_relid,
+                bool_or(column_name = 'dropped') AS has_dropped
+            FROM information_schema.columns
+            WHERE table_schema = '_timescaledb_catalog'
+              AND table_name = 'chunk'
+            ",
+            &[],
+        )
+        .await?;
+    Ok((row.get("has_relid"), row.get("has_dropped")))
+}
 
 pub async fn initialize_features(target: &Target) -> Result<()> {
-    let ts_version = &Version::parse(&fetch_tsdb_version(&target.client).await?)?;
+    let mut ts_version = Version::parse(&fetch_tsdb_version(&target.client).await?)?;
+    // Nightly builds report a prerelease version (e.g. `2.29.0-dev`). By semver
+    // rules a prerelease only satisfies a comparator that itself carries a
+    // prerelease with the same major.minor.patch, so a plain `>=X.Y.Z` would
+    // match none of the checks below. Drop the prerelease so a nightly is
+    // treated as its target release for feature gating.
+    ts_version.pre = semver::Prerelease::EMPTY;
+    let ts_version = &ts_version;
     let pg_version = fetch_pg_version_number(&target.client).await?;
+    let (chunk_has_relid, chunk_has_dropped) = fetch_chunk_catalog_columns(target).await?;
 
     let ts_lt_222 = VersionReq::parse("<2.22.0").unwrap().matches(ts_version);
     let ts_ge_219 = VersionReq::parse(">=2.19.0").unwrap().matches(ts_version);
@@ -58,6 +93,14 @@ pub async fn initialize_features(target: &Target) -> Result<()> {
     HYPERCORE_TAM
         .set(ts_ge_218 && ts_lt_222)
         .map_err(|e| anyhow!("HYPERCORE_TAM already set to {}", e))?;
+
+    CHUNK_CATALOG_USES_RELID
+        .set(chunk_has_relid)
+        .map_err(|e| anyhow!("CHUNK_CATALOG_USES_RELID already set to {}", e))?;
+
+    CHUNK_HAS_DROPPED_COLUMN
+        .set(chunk_has_dropped)
+        .map_err(|e| anyhow!("CHUNK_HAS_DROPPED_COLUMN already set to {}", e))?;
     Ok(())
 }
 
@@ -99,4 +142,26 @@ pub fn compression_settings_with_compress_relid() -> bool {
 // Supported from TS >= 2.18.0 to < 2.22.0
 pub fn hypercore_tam() -> bool {
     *HYPERCORE_TAM.get().expect("HYPERCORE_TAM is not set")
+}
+
+// Detected, not version-gated. Starting with TS 2.29 the
+// `_timescaledb_catalog.chunk` table stores the chunk's relation as a `relid`
+// (regclass) instead of the `schema_name` / `table_name` pair and no longer
+// tracks `compressed_chunk_id`. The compressed relation for a chunk is found
+// through `compression_settings.compress_relid` and its size through
+// `compression_chunk_size.chunk_id`.
+pub fn chunk_catalog_uses_relid() -> bool {
+    *CHUNK_CATALOG_USES_RELID
+        .get()
+        .expect("CHUNK_CATALOG_USES_RELID is not set")
+}
+
+// Detected, not version-gated. The `dropped` column was removed from
+// `_timescaledb_catalog.chunk` around TS 2.26; from then on dropped chunks are
+// removed from the catalog rather than kept as tombstones, so no filter is
+// needed.
+pub fn chunk_has_dropped_column() -> bool {
+    *CHUNK_HAS_DROPPED_COLUMN
+        .get()
+        .expect("CHUNK_HAS_DROPPED_COLUMN is not set")
 }

--- a/src/find_source_chunks.sql
+++ b/src/find_source_chunks.sql
@@ -96,8 +96,8 @@ with recursive f as
     from down
 )
 select
-  c.schema_name as chunk_schema
-, c.table_name as chunk_name
+  @chunk_schema@ as chunk_schema
+, @chunk_name@ as chunk_name
 , h.schema_name as hypertable_schema
 , h.table_name as hypertable_name
 , (
@@ -185,6 +185,7 @@ inner join _timescaledb_catalog.dimension_slice ds
 on (d.id = ds.dimension_id and ds.range_start < d.upper_value and (d.lower_value is null or d.lower_value < ds.range_end))
 inner join _timescaledb_catalog.chunk_constraint cc on (ds.id = cc.dimension_slice_id)
 inner join _timescaledb_catalog.chunk c on (cc.chunk_id = c.id and h.id = c.hypertable_id)
-where c.dropped = false
+@chunk_relid_join@
+@dropped_filter@
 order by ds.range_start desc
 ;

--- a/src/find_target_chunk.sql
+++ b/src/find_target_chunk.sql
@@ -6,8 +6,8 @@ select
 from
 (
     select
-      c.schema_name as chunk_schema
-    , c.table_name as chunk_name
+      @chunk_schema@ as chunk_schema
+    , @chunk_name@ as chunk_name
     , h.schema_name as hypertable_schema
     , h.table_name as hypertable_name
     , count(distinct ds.id) as nbr_dimension_slices
@@ -18,6 +18,7 @@ from
     inner join _timescaledb_catalog.dimension_slice ds on (d.id = ds.dimension_id and ds.range_start = i.range_start and ds.range_end = i.range_end)
     inner join _timescaledb_catalog.chunk_constraint cc on (ds.id = cc.dimension_slice_id)
     inner join _timescaledb_catalog.chunk c on (cc.chunk_id = c.id)
+    @chunk_relid_join@
     where h.schema_name = $1
     and h.table_name = $2
     group by 1, 2, 3, 4

--- a/src/task.rs
+++ b/src/task.rs
@@ -5,7 +5,8 @@ use crate::execute::{
 use crate::sql::assert_regex;
 use crate::storage::{backfill_schema_exists, init_schema};
 use crate::timescale::{
-    set_query_source_proc_schema, Hypertable, QuotedName, SourceChunk, TargetChunk,
+    set_query_chunk_catalog, set_query_source_proc_schema, Hypertable, QuotedName, SourceChunk,
+    TargetChunk,
 };
 use crate::{features, TERM};
 use anyhow::{bail, Result};
@@ -97,10 +98,11 @@ pub async fn find_target_chunk_with_same_dimensions(
     source_chunk: &SourceChunk,
 ) -> Result<TargetChunk> {
     static FIND_TARGET_CHUNK: &str = include_str!("find_target_chunk.sql");
+    let find_target_chunk = set_query_chunk_catalog(FIND_TARGET_CHUNK);
 
     let row = target_tx
         .query_opt(
-            FIND_TARGET_CHUNK,
+            &find_target_chunk,
             &[
                 &source_chunk.hypertable.schema,
                 &source_chunk.hypertable.table,
@@ -206,7 +208,7 @@ pub async fn load_queue(
 
     let target_tx = target.client.transaction().await?;
     static FIND_SOURCE_CHUNKS: &str = include_str!("find_source_chunks.sql");
-    let query = set_query_source_proc_schema(FIND_SOURCE_CHUNKS);
+    let query = set_query_chunk_catalog(&set_query_source_proc_schema(FIND_SOURCE_CHUNKS));
     let source_tx = source.transaction().await?;
 
     let rows = match source_tx

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -67,6 +67,47 @@ pub fn set_query_target_proc_schema(query: &str) -> String {
     query.replace(EXTSCHEMA, schema)
 }
 
+/// Lateral join that resolves a chunk's `relid` to its `schema`/`table` for the
+/// relid catalog (TS >= 2.29). It assumes the chunk table is aliased `c`.
+const CHUNK_RELID_JOIN: &str = "
+inner join lateral (
+    select nc.nspname, clc.relname
+    from pg_class clc
+    join pg_namespace nc on nc.oid = clc.relnamespace
+    where clc.oid = c.relid
+) chunk_rel on true";
+
+/// Fills in the chunk-catalog placeholders in a query so it targets either the
+/// pre-relid catalog (`schema_name`/`table_name`/`dropped` columns) or the
+/// relid catalog (TS >= 2.29, where the chunk relation is resolved from
+/// `relid`). The chunk table must be aliased `c`.
+///
+/// Placeholders:
+/// - `@chunk_schema@` / `@chunk_name@`: the chunk's schema/table expressions
+/// - `@chunk_relid_join@`: join that exposes them in the relid catalog
+/// - `@dropped_filter@`: the `dropped = false` filter, absent in the relid
+///   catalog (dropped chunks are removed from it)
+pub fn set_query_chunk_catalog(query: &str) -> String {
+    let (chunk_schema, chunk_name, chunk_relid_join) =
+        if crate::features::chunk_catalog_uses_relid() {
+            ("chunk_rel.nspname", "chunk_rel.relname", CHUNK_RELID_JOIN)
+        } else {
+            ("c.schema_name", "c.table_name", "")
+        };
+    // The `dropped` column was removed before the relid change, so it is gated
+    // independently.
+    let dropped_filter = if crate::features::chunk_has_dropped_column() {
+        "where c.dropped = false"
+    } else {
+        ""
+    };
+    query
+        .replace("@chunk_schema@", chunk_schema)
+        .replace("@chunk_name@", chunk_name)
+        .replace("@chunk_relid_join@", chunk_relid_join)
+        .replace("@dropped_filter@", dropped_filter)
+}
+
 pub async fn fetch_tsdb_version<T: GenericClient>(client: &T) -> Result<String> {
     let tsdb_version = client
         .query_one(

--- a/test-common/Cargo.toml
+++ b/test-common/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "test-common"
+version = "0.22.0"
+edition = "2021"
+rust-version = "1.65.0"
+
+[dependencies]
+chrono = "0.4.31"
+serde_json = "1.0.107"
+tempfile = { version = "3.8.0", default-features = false }
+tokio = { version = "1.32.0", features = ["fs", "io-util", "macros", "rt-multi-thread", "signal", "time"], default-features = false }
+tokio-postgres = { version = "0.7.10", features = ["runtime", "with-serde_json-1"], default-features = false }
+tokio-postgres-rustls = { version = "0.10.0", default-features = false }
+assert_cmd = "2.0.12"
+assert_fs = "1.0.13"
+glob = "0.3.1"
+log = "0.4.20"
+postgres = "0.19.7"
+predicates = "3.0.4"
+pretty_env_logger = "0.5.0"
+testcontainers = "0.14.0"
+thiserror = "1.0.50"

--- a/test-common/src/assert_within.rs
+++ b/test-common/src/assert_within.rs
@@ -1,0 +1,48 @@
+/// Assert that two numbers are within tolerance percent of one another
+///
+/// Example:
+/// ```rust
+///     # #[macro_use] extern crate test_common;
+///     # fn main() {
+///         // Asserts that 90 and 100 are within 10% of one another
+///         assert_within!(100, 90, 0.10);
+///     # }
+/// ```
+#[macro_export]
+macro_rules! assert_within {
+    ($a:expr, $b:expr, $tolerance:expr) => {
+        let min = f64::min($a as f64, $b as f64);
+        let max = f64::max($a as f64, $b as f64);
+
+        let actual_ratio = 1f64 - (min / max);
+
+        assert!(
+            actual_ratio < $tolerance,
+            "{} and {} are not within {} of one another (actually {:.2})",
+            $a,
+            $b,
+            $tolerance,
+            actual_ratio
+        );
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[should_panic(expected = "90 and 100 are not within 0.01 of one another (actually 0.10)")]
+    fn panics_when_not_in_range() {
+        assert_within!(90, 100, 0.01);
+    }
+
+    #[test]
+    #[should_panic(expected = "100 and 90 are not within 0.01 of one another (actually 0.10)")]
+    fn panics_when_not_in_range_order_independent() {
+        assert_within!(100, 90, 0.01);
+    }
+
+    #[test]
+    fn no_panic_when_in_range() {
+        assert_within!(100, 90, 0.10);
+    }
+}

--- a/test-common/src/cloud.rs
+++ b/test-common/src/cloud.rs
@@ -1,0 +1,23 @@
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+use crate::psql::{psql, PsqlError, PsqlInput};
+use crate::test_connection_string::HasConnectionString;
+
+const CLOUD_INIT: &[u8] = include_bytes!("cloud_init.sql");
+
+/// Timescale cloud has special configuration which restricts which actions can
+/// be performed in the database instance. This function performs the following
+/// actions:
+/// - Creates the `tsdbadmin` role
+/// - Creates the `tsdb` database, with owner `tsdbadmin`
+/// - Applies most (?) of the restrictions which Timescale cloud does
+///   Note: it's somewhat non-trivial to know exactly which restrictions are
+///   applied. We cherry-picked these from: https://github.com/timescale/timescaledb-operator/blob/6b99a24ff1d72751249e4238db54b84e54e351a3/operator/pkg/options/scripts/after-create.sql
+pub fn configure_cloud_setup<C: HasConnectionString>(container: &C) -> Result<(), PsqlError> {
+    let mut script_file = NamedTempFile::new()?;
+    script_file.write_all(CLOUD_INIT)?;
+    let path = script_file.path();
+    psql(&container, PsqlInput::File(path))?;
+    Ok(())
+}

--- a/test-common/src/cloud_init.sql
+++ b/test-common/src/cloud_init.sql
@@ -1,0 +1,272 @@
+-- Last update applied:
+-- https://github.com/timescale/timescaledb-operator/commits/9b0098ad28fae5a9c4afb513cc0e60c421d4885c/operator/pkg/options/scripts/timescale-after-create.sql
+CREATE ROLE tsdbadmin WITH LOGIN;
+CREATE DATABASE tsdb WITH OWNER tsdbadmin;
+
+\c tsdb;
+
+ALTER FUNCTION public.timescaledb_pre_restore() SET search_path = pg_catalog,pg_temp SECURITY DEFINER;
+ALTER FUNCTION public.timescaledb_post_restore() SET search_path = pg_catalog,pg_temp SECURITY DEFINER;
+REVOKE EXECUTE ON FUNCTION public.timescaledb_pre_restore() FROM public;
+REVOKE EXECUTE ON FUNCTION public.timescaledb_post_restore() FROM public;
+GRANT EXECUTE ON FUNCTION public.timescaledb_pre_restore() TO tsdbadmin;
+GRANT EXECUTE ON FUNCTION public.timescaledb_post_restore() TO tsdbadmin;
+
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON ALL TABLES IN SCHEMA _timescaledb_cache FROM tsdbadmin;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON ALL TABLES IN SCHEMA _timescaledb_catalog FROM tsdbadmin;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON ALL TABLES IN SCHEMA _timescaledb_config FROM tsdbadmin;
+-- only revoke permissions from non-chunks tables in _timescaledb_internal
+DO $$
+    BEGIN
+        IF EXISTS (
+            SELECT 1
+            FROM pg_catalog.pg_class
+            WHERE relname = 'bgw_job_stat' AND
+                    relnamespace = '_timescaledb_internal'::regnamespace::oid
+        )
+        THEN
+            REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE _timescaledb_internal.bgw_job_stat FROM tsdbadmin;
+        END IF;
+        IF EXISTS (
+            SELECT 1
+            FROM pg_catalog.pg_class
+            WHERE relname = 'bgw_policy_chunk_stats' AND
+                    relnamespace = '_timescaledb_internal'::regnamespace::oid
+        )
+        THEN
+            REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE _timescaledb_internal.bgw_policy_chunk_stats FROM tsdbadmin;
+        END IF;
+        IF EXISTS (
+            SELECT 1
+            FROM pg_catalog.pg_class
+            WHERE relname = 'hypertable_chunk_local_size' AND
+                    relnamespace = '_timescaledb_internal'::regnamespace::oid
+        )
+        THEN
+            REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE _timescaledb_internal.hypertable_chunk_local_size FROM tsdbadmin;
+        END IF;
+        IF EXISTS (
+            SELECT 1
+            FROM pg_catalog.pg_class
+            WHERE relname = 'compressed_chunk_stats' AND
+                    relnamespace = '_timescaledb_internal'::regnamespace::oid
+        )
+        THEN
+            REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE _timescaledb_internal.compressed_chunk_stats FROM tsdbadmin;
+        END IF;
+    END
+$$;
+
+REVOKE UPDATE ON ALL SEQUENCES IN SCHEMA _timescaledb_cache FROM tsdbadmin;
+REVOKE UPDATE ON ALL SEQUENCES IN SCHEMA _timescaledb_catalog FROM tsdbadmin;
+REVOKE UPDATE ON ALL SEQUENCES IN SCHEMA _timescaledb_config FROM tsdbadmin;
+
+REVOKE CREATE ON SCHEMA _timescaledb_cache FROM tsdbadmin;
+REVOKE CREATE ON SCHEMA _timescaledb_catalog FROM tsdbadmin;
+REVOKE CREATE ON SCHEMA _timescaledb_config FROM tsdbadmin;
+REVOKE CREATE ON SCHEMA _timescaledb_internal FROM tsdbadmin;
+
+
+-- we don't use CREATE OR REPLACE FUNCTION here, as REPLACE will keep the permissions of the original user,
+-- opening us to an attack where the less-privileged user creates a "bait" function, waiting for the extension
+-- to be created or updated and replacing the trigger function subsequently to its own version. For that reason,
+-- we also check precisely the properties of the function (owner, arguments, language) when skipping its creation.
+DO $do$
+    BEGIN
+        IF NOT EXISTS(
+            SELECT 1
+            FROM pg_catalog.pg_proc
+            WHERE pronamespace = 'public'::regnamespace::oid AND
+                    proname = 'validate_job_role' AND
+                    pg_catalog.pg_get_userbyid(proowner) = 'postgres' AND
+                    pronargs = 0 AND
+                    prorettype = 'trigger'::regtype::oid AND
+                    prolang = (SELECT oid FROM pg_catalog.pg_language WHERE lanname = 'plpgsql')
+        )
+        THEN
+            -- if the function exists, but not with the ownership or other properties of the desired one, complain here
+            -- We avoid CREATE FUNCTION to error out because of a duplicate, as its error message would be confusing to the user.
+            IF EXISTS(
+                SELECT 1
+                FROM pg_catalog.pg_proc
+                WHERE pronamespace = 'public'::regnamespace::oid AND
+                        proname = 'validate_job_role'
+            )
+            THEN
+                RAISE EXCEPTION 'Function public.validate_job_role is already defined by the user'
+                    USING HINT='Drop the function and retry';
+            END IF;
+            CREATE FUNCTION public.validate_job_role() RETURNS TRIGGER LANGUAGE plpgsql AS $tg$
+      DECLARE
+        roleowner    name;
+      BEGIN
+        IF (TG_OP = 'INSERT' OR TG_OP = 'UPDATE') THEN
+          roleowner = NEW.owner;
+        ELSE
+          RAISE EXCEPTION '% is installed for %', TG_NAME, TG_OP
+            USING HINT = 'trigger should only be installed for INSERT or UPDATE';
+        END IF;
+        if roleowner IS NULL THEN
+          RAISE EXCEPTION 'owner field of %.% cannot be NULL', TG_TABLE_SCHEMA, TG_TABLE_NAME;
+        END IF;
+        IF (SELECT rolsuper FROM pg_catalog.pg_roles WHERE rolname = current_role)
+        THEN
+          -- superusers do what they want
+          RETURN NEW;
+        END IF;
+        IF (SELECT current_setting('timescaledb.restoring')::bool = true AND roleowner = 'postgres') THEN
+          -- if the owner was postgres and we are restoring (i.e. this is a
+          -- dump from self-hosted timescale), rewrite owner to current_user.
+          NEW.owner := current_user;
+          return NEW;
+        END IF;
+
+        -- When roleowner has capital letters, it is wrapped in quotes, eg, "testRole". This fails pg_has_role() check.
+        -- Using `roleowner::regrole` fixes the issue.
+        IF NOT pg_catalog.pg_has_role(current_role, roleowner::regrole, 'MEMBER') THEN
+          RAISE EXCEPTION 'Cannot % table %.% row ID %', TG_OP, TG_TABLE_SCHEMA, TG_TABLE_NAME, NEW.id USING HINT = 'owner is not a member of the current role',
+          ERRCODE = '42501';
+        END IF;
+        RETURN NEW;
+      END
+      $tg$ SET search_path = pg_catalog;
+            -- make sure the function is dropped together with the extension
+            ALTER EXTENSION timescaledb ADD FUNCTION public.validate_job_role();
+        END IF;
+    END
+$do$;
+
+
+DO $$
+    BEGIN
+      IF pg_catalog.to_regclass('_timescaledb_internal.bgw_job_stat_history') IS NOT NULL THEN
+            -- In TimescaleDB 2.23+ bgw_job became a view; the UPDATE and pg_attribute
+            -- lookup only work when it is still a plain table.
+            IF (SELECT relkind FROM pg_catalog.pg_class WHERE oid = '_timescaledb_config.bgw_job'::regclass) = 'r' THEN
+                -- Ensure the error-retention policy job is owned by tsdbadmin.
+                -- The job having id == 2 is hardcoded in TimescaleDB:
+                -- https://github.com/timescale/timescaledb/blob/7a6101a441ca4ad02018ffddd225e7abdea4385f/sql/job_error_log_retention.sql#L60
+                UPDATE
+                    _timescaledb_config.bgw_job
+                SET
+                    owner = 'tsdbadmin'::regrole
+                WHERE
+                        id = 2
+                  AND owner != 'tsdbadmin'::regrole
+                  AND proc_name IN ('policy_job_error_retention', 'policy_job_stat_history_retention')
+                  AND proc_schema IN ('_timescaledb_internal', '_timescaledb_functions');
+            END IF;
+
+            GRANT DELETE ON _timescaledb_internal.bgw_job_stat_history TO tsdbadmin;
+        END IF;
+    END;
+$$;
+
+-- we need to block manually inserting or changing the owner field of the jobs timescale catalog, to avoid
+-- a job running as a superuser or a user the current_user is not a member of. Otherwise, we may get privileges
+-- escalation. Check the trigger is not disabled and is BEFORE ROW INSERT or UPDATE (tgtype controls that) one.
+-- In TimescaleDB 2.23+ bgw_job became a view, which cannot have row-level triggers, so skip this.
+DO $$
+    BEGIN
+        -- Only create the trigger if bgw_job is a table (not a view)
+        IF (SELECT relkind FROM pg_catalog.pg_class WHERE oid = '_timescaledb_config.bgw_job'::regclass) = 'r' THEN
+            IF NOT EXISTS(
+                SELECT 1
+                FROM pg_catalog.pg_trigger
+                WHERE tgname = 'validate_job_role_trigger'
+                  AND tgrelid = '_timescaledb_config.bgw_job'::regclass::oid
+                  AND tgfoid = 'public.validate_job_role()'::regprocedure::oid
+                  AND tgenabled IN ('O', 'A') AND tgtype = 23
+            )
+            THEN
+                -- see the comment at the function creation about avoiding a confusing error message
+                IF EXISTS(
+                    SELECT 1 FROM pg_catalog.pg_trigger
+                    WHERE tgname = 'validate_job_role_trigger'
+                )
+                THEN
+                    RAISE EXCEPTION 'Trigger validate_job_role_trigger is already defined by the user'
+                        USING HINT='Drop the trigger and retry';
+                END IF;
+                CREATE TRIGGER validate_job_role_trigger
+                    BEFORE INSERT OR UPDATE ON _timescaledb_config.bgw_job
+                    FOR EACH ROW EXECUTE FUNCTION public.validate_job_role();
+            END IF;
+        END IF;
+    END
+$$;
+
+
+-- add mostly insert permissions to be able to restore a dump. We only add those for the tables that have their
+-- data dumped separately from the `CREATE EXTENSION` (the so-called extension configuration tables, see
+-- https://www.postgresql.org/docs/current/extend-extensions.html#EXTEND-EXTENSIONS-CONFIG-TABLES
+
+DO $$
+    DECLARE
+        relid name;
+    BEGIN
+        -- we need to grant insert on the extension tables (pg_restore must be able to add the data dumped previously, and
+        -- update on sequences, so that pg_restore or the user would able to use setval for sequences to fix them).
+        FOR relid in (
+            SELECT cfg.relid
+            FROM pg_catalog.pg_extension
+                     JOIN LATERAL unnest(extconfig) as cfg(relid) on true
+            WHERE extname = 'timescaledb'
+              AND (pg_catalog.pg_identify_object('pg_catalog.pg_class'::regclass::oid, cfg.relid, 0)).type = 'sequence'
+        )
+            LOOP
+                EXECUTE pg_catalog.format('GRANT UPDATE ON SEQUENCE %s TO tsdbadmin', relid::regclass::text);
+            END LOOP;
+
+        -- we only need extension configuration tables (their data is dumped separately from CREATE EXTENSION)
+        FOR relid in (
+            SELECT cfg.relid
+            FROM pg_catalog.pg_extension
+                     JOIN LATERAL pg_catalog.unnest(extconfig) as cfg(relid) on true
+            WHERE extname = 'timescaledb'
+              AND (pg_catalog.pg_identify_object('pg_catalog.pg_class'::regclass::oid, cfg.relid, 0)).type = 'table'
+        )
+            LOOP
+                EXECUTE pg_catalog.format('GRANT INSERT ON TABLE %s TO tsdbadmin', relid::regclass::text);
+                -- tsdbadmin requires update permissions on cagg migration tables (related PR timescale/timestaledb#4552)
+                IF relid::regclass::text ~ 'continuous_agg_migrate_plan(|_step)$' THEN
+                    EXECUTE pg_catalog.format('GRANT UPDATE ON TABLE %s TO tsdbadmin', relid::regclass::text);
+                END IF;
+            END LOOP;
+
+        -- The telemetry events table is intended for application data (like cli tools)
+        -- that should be included in telemetry.
+        IF EXISTS (
+            SELECT FROM pg_tables
+            WHERE schemaname = '_timescaledb_catalog'
+              AND tablename = 'telemetry_event'
+        ) THEN
+            GRANT INSERT ON TABLE _timescaledb_catalog.telemetry_event TO tsdbadmin;
+        END IF;
+
+        -- We should allow the creation of new chunk tables within the _timescaledb_internal schema using pg_restore.
+        -- Although we could implement an event trigger to specifically filter chunk tables, this may be unnecessary since
+        -- the schema primarily contains _stat tables and chunks, and it's improbable that we would introduce any new stat
+        -- tables in the future. We add GRANT OPTION to allow tsdbadmin to grant create privileges TO other roles; this is
+        -- necessary, i.e. to change the continuous aggregate owner, matching owner of the job that does the referesh policy.
+        -- See https://github.com/timescale/timescaledb/issues/5745 for the bugreport that would be impossible to fix without
+        -- the GRANT OPTION.
+        GRANT CREATE ON SCHEMA _timescaledb_internal TO tsdbadmin WITH GRANT OPTION;
+
+        -- Workaround for https://github.com/timescale/timescaledb/issues/5449
+        -- Long story short:
+        -- - pg_dump takes out locks on *all* extension tables
+        -- - excluding them from pg_dump does not work
+        -- - without this fix, a user gets: pg_dump: error: query failed: ERROR:  permission denied for table job_errors
+        BEGIN
+            -- The NOT has_table_privilege only returns TRUE if:
+            -- - grantee exists (if not, it will raise an exception)
+            -- - job_table exists (otherwise, it will return NULL)
+            -- - SELECT privs are missing
+            IF NOT pg_catalog.has_table_privilege('tsdbadmin', pg_catalog.to_regclass('_timescaledb_internal.bgw_job_stat_history'), 'SELECT WITH GRANT OPTION')
+            THEN
+                GRANT SELECT ON _timescaledb_internal.bgw_job_stat_history TO tsdbadmin WITH GRANT OPTION;
+            END IF;
+        END;
+    END
+$$;

--- a/test-common/src/db_assert.rs
+++ b/test-common/src/db_assert.rs
@@ -1,0 +1,1197 @@
+use postgres::{Client, Config};
+use serde_json::Value;
+use std::str::FromStr;
+use thiserror::Error;
+use tokio_postgres::{NoTls, Row};
+
+use crate::{HasConnectionString, JsonAssert, TestConnectionString};
+
+#[derive(Debug, Error)]
+pub enum DbAssertError {
+    #[error("postgres error")]
+    PostgresError(#[from] tokio_postgres::Error),
+}
+
+pub struct DbAssert {
+    client: Client,
+    name: Option<String>,
+}
+
+type Result<T> = std::result::Result<T, DbAssertError>;
+
+impl DbAssert {
+    pub fn new(dsn: &TestConnectionString) -> Result<Self> {
+        let config = Config::from_str(dsn.connection_string().as_str())?;
+        let client = config.connect(NoTls)?;
+
+        Ok(Self { client, name: None })
+    }
+
+    pub fn with_name<T: AsRef<str>>(mut self, name: T) -> Self {
+        self.name = Some(String::from(name.as_ref()));
+        self
+    }
+
+    pub fn connection(&mut self) -> &mut Client {
+        &mut self.client
+    }
+
+    pub fn has_extension_version<T: AsRef<str>>(&mut self, extension: T, version: T) -> &mut Self {
+        let extension = extension.as_ref();
+        let version = version.as_ref();
+        let ext_ver: Option<String> = self._get_installed_extension_version(extension).unwrap();
+        assert!(
+            ext_ver.is_some(),
+            "{}extension '{}' is not installed",
+            self.name(),
+            extension
+        );
+        let ext_ver = ext_ver.unwrap();
+        assert_eq!(
+            ext_ver,
+            version,
+            "{}extension '{}' version is '{}', not '{}'",
+            self.name(),
+            extension,
+            ext_ver,
+            version
+        );
+        self
+    }
+
+    pub fn has_schema<T: AsRef<str>>(&mut self, schema: T) -> &mut Self {
+        assert!(
+            self._has_schema(schema.as_ref()).unwrap(),
+            "{}schema '{}' doesn't exist",
+            self.name(),
+            schema.as_ref()
+        );
+        self
+    }
+
+    pub fn not_has_schema<T: AsRef<str>>(&mut self, schema: T) -> &mut Self {
+        assert!(
+            !self._has_schema(schema.as_ref()).unwrap(),
+            "{}schema '{}' exists",
+            self.name(),
+            schema.as_ref()
+        );
+        self
+    }
+
+    pub fn has_table<T: AsRef<str>>(&mut self, schema: T, table: T) -> &mut Self {
+        assert!(
+            self._has_table(schema.as_ref(), table.as_ref()).unwrap(),
+            "{}table '{}.{}' doesn't exist",
+            self.name(),
+            schema.as_ref(),
+            table.as_ref()
+        );
+        self
+    }
+
+    pub fn not_has_table<T: AsRef<str>>(&mut self, schema: T, table: T) -> &mut Self {
+        assert!(
+            !self._has_table(schema.as_ref(), table.as_ref()).unwrap(),
+            "{}table '{}.{}' exists",
+            self.name(),
+            schema.as_ref(),
+            table.as_ref()
+        );
+        self
+    }
+
+    pub fn is_true<T: AsRef<str>>(&mut self, query: T) -> &mut Self {
+        assert!(
+            self._is_true(query.as_ref()),
+            "{}query '{}' is not returning true",
+            self.name(),
+            query.as_ref()
+        );
+        self
+    }
+
+    pub fn is_false<T: AsRef<str>>(&mut self, query: T) -> &mut Self {
+        assert!(
+            !self._is_true(query.as_ref()),
+            "{}query '{}' is not returning false",
+            self.name(),
+            query.as_ref()
+        );
+        self
+    }
+
+    pub fn has_hypertable<T: AsRef<str>>(&mut self, schema: T, table: T) -> &mut Self {
+        let table_exists = self._has_table(schema.as_ref(), table.as_ref()).unwrap();
+        assert!(
+            table_exists,
+            "{} table '{}.{}' does not exist",
+            self.name(),
+            schema.as_ref(),
+            table.as_ref()
+        );
+        let is_hypertable = self
+            ._has_hypertable(schema.as_ref(), table.as_ref())
+            .unwrap();
+        assert!(
+            is_hypertable,
+            "{} table '{}.{}' is not a hypertable",
+            self.name(),
+            schema.as_ref(),
+            table.as_ref()
+        );
+        self
+    }
+
+    pub fn not_has_hypertable<T: AsRef<str>>(&mut self, schema: T, table: T) -> &mut Self {
+        assert!(
+            !self
+                ._has_hypertable(schema.as_ref(), table.as_ref())
+                .unwrap(),
+            "{}hypertable '{}.{}' exists",
+            self.name(),
+            schema.as_ref(),
+            table.as_ref(),
+        );
+        self
+    }
+
+    pub fn has_table_count<T: AsRef<str>>(&mut self, schema: T, table: T, count: i64) -> &mut Self {
+        self.has_table(schema.as_ref(), table.as_ref());
+        let table_count = self
+            ._get_table_count(schema.as_ref(), table.as_ref())
+            .unwrap();
+        assert_eq!(
+            table_count,
+            count,
+            "{}table '{}.{}' count is '{}', not '{}'",
+            self.name(),
+            schema.as_ref(),
+            table.as_ref(),
+            table_count,
+            count
+        );
+        self
+    }
+
+    pub fn has_fk_constraint_named<T: AsRef<str>>(&mut self, fk_constraint_name: T) -> &mut Self {
+        assert!(
+            self._has_fk_constraint_named(fk_constraint_name.as_ref())
+                .unwrap(),
+            "{}no foreign key constraint named '{}'",
+            self.name(),
+            fk_constraint_name.as_ref()
+        );
+        self
+    }
+
+    pub fn has_cagg_mt_chunk_count<T: AsRef<str>>(
+        &mut self,
+        schema: T,
+        table: T,
+        count: i64,
+    ) -> &mut Self {
+        let (mt_schema, mt_table) = self
+            ._get_cagg_materialized_table(schema.as_ref(), table.as_ref())
+            .unwrap();
+        self.has_chunk_count(mt_schema, mt_table, count);
+        self
+    }
+
+    pub fn has_chunk_count<T: AsRef<str>>(&mut self, schema: T, table: T, count: i64) -> &mut Self {
+        self.has_table(schema.as_ref(), table.as_ref());
+        let chunk_count = self
+            ._get_chunk_count(schema.as_ref(), table.as_ref())
+            .unwrap();
+        assert_eq!(
+            chunk_count,
+            count,
+            "{}table '{}.{}' chunk count is '{}', not '{}'",
+            self.name(),
+            schema.as_ref(),
+            table.as_ref(),
+            chunk_count,
+            count
+        );
+        self
+    }
+
+    pub fn has_compressed_chunk_count<T: AsRef<str>>(
+        &mut self,
+        schema: T,
+        table: T,
+        count: i64,
+    ) -> &mut Self {
+        self.has_table(schema.as_ref(), table.as_ref());
+        let chunk_count = self
+            ._get_compressed_chunk_count(schema.as_ref(), table.as_ref())
+            .unwrap();
+        assert_eq!(
+            chunk_count,
+            count,
+            "{}table '{}.{}' compressed chunk count is '{}', not '{}'",
+            self.name(),
+            schema.as_ref(),
+            table.as_ref(),
+            chunk_count,
+            count
+        );
+        self
+    }
+
+    pub fn has_sequence<T: AsRef<str>>(&mut self, schema: T, sequence: T) -> &mut Self {
+        assert!(
+            self._has_sequence(schema.as_ref(), sequence.as_ref())
+                .unwrap(),
+            "{}sequence '{}.{}' does not exist",
+            self.name(),
+            schema.as_ref(),
+            sequence.as_ref()
+        );
+        self
+    }
+
+    pub fn not_has_sequence<T: AsRef<str>>(&mut self, schema: T, sequence: T) -> &mut Self {
+        assert!(
+            !self
+                ._has_sequence(schema.as_ref(), sequence.as_ref())
+                .unwrap(),
+            "{}sequence '{}.{}' exists",
+            self.name(),
+            schema.as_ref(),
+            sequence.as_ref()
+        );
+        self
+    }
+
+    /// Assert that the sequence '`schema`.`sequence` exists, and has the `last_value` as its
+    /// last value. Sequences which have not yet been `nextval`'d have a `last_value` of `None`.
+    pub fn has_sequence_last_value<T: AsRef<str>>(
+        &mut self,
+        schema: T,
+        sequence: T,
+        last_value: Option<i64>,
+    ) -> &mut Self {
+        self.has_sequence(schema.as_ref(), sequence.as_ref());
+
+        let sequence_value = self
+            ._sequence_value(schema.as_ref(), sequence.as_ref())
+            .unwrap();
+
+        assert_eq!(sequence_value, last_value);
+        self
+    }
+
+    pub fn has_user_defined_job<T: AsRef<str>>(&mut self, proc_name: T, owner: T) -> &mut Self {
+        assert!(
+            self._has_job(None, None, proc_name.as_ref()).unwrap(),
+            "{}job '{}' not found",
+            self.name(),
+            proc_name.as_ref()
+        );
+        assert!(
+            self._has_job_owner(None, None, proc_name.as_ref(), owner.as_ref())
+                .unwrap(),
+            "{}job '{}' not owned by '{}'",
+            self.name(),
+            proc_name.as_ref(),
+            owner.as_ref(),
+        );
+        self
+    }
+
+    pub fn has_scheduled_job<T: AsRef<str>>(
+        &mut self,
+        schema: T,
+        table: T,
+        proc_name: T,
+        owner: T,
+    ) -> &mut Self {
+        assert!(
+            self._has_job(
+                Some(schema.as_ref()),
+                Some(table.as_ref()),
+                proc_name.as_ref()
+            )
+            .unwrap(),
+            "{}job '{}' for '{}.{}' not found",
+            self.name(),
+            proc_name.as_ref(),
+            schema.as_ref(),
+            table.as_ref(),
+        );
+        assert!(
+            self._has_job_owner(
+                Some(schema.as_ref()),
+                Some(table.as_ref()),
+                proc_name.as_ref(),
+                owner.as_ref()
+            )
+            .unwrap(),
+            "{}job '{}' owned by {} for '{:?}.{:?}' not found",
+            self.name(),
+            proc_name.as_ref(),
+            owner.as_ref(),
+            schema.as_ref(),
+            table.as_ref(),
+        );
+        assert!(
+            self._has_job_scheduled(
+                schema.as_ref(),
+                table.as_ref(),
+                proc_name.as_ref(),
+                owner.as_ref()
+            )
+            .unwrap(),
+            "{}job '{}' owned by {} for '{:?}.{:?}' is not scheduled",
+            self.name(),
+            proc_name.as_ref(),
+            owner.as_ref(),
+            schema.as_ref(),
+            table.as_ref(),
+        );
+        self
+    }
+
+    pub fn has_task_count(&mut self, count: i64) -> &mut Self {
+        let task_count = self._get_task_count().unwrap();
+        assert_eq!(
+            task_count,
+            count,
+            "{}task count is '{}', not '{}'",
+            self.name(),
+            task_count,
+            count
+        );
+        self
+    }
+
+    pub fn has_task_count_for_table<T: AsRef<str>>(
+        &mut self,
+        schema: T,
+        table: T,
+        count: i64,
+    ) -> &mut Self {
+        let task_count = self
+            ._get_task_count_for_table(schema.as_ref(), table.as_ref())
+            .unwrap();
+        assert_eq!(
+            task_count,
+            count,
+            "{}task count for '{}.{}' is '{}', not '{}'",
+            self.name(),
+            schema.as_ref(),
+            table.as_ref(),
+            task_count,
+            count
+        );
+        self
+    }
+
+    pub fn job_runs_successfully<T: AsRef<str>>(
+        &mut self,
+        schema: T,
+        table: T,
+        proc_name: T,
+        owner: T,
+    ) -> &mut Self {
+        let job_id = self._get_job_id(
+            schema.as_ref(),
+            table.as_ref(),
+            proc_name.as_ref(),
+            owner.as_ref(),
+        );
+        self.connection()
+            .execute("CALL run_job($1)", &[&job_id])
+            .unwrap();
+        let last_run_status = self._last_run_status(job_id);
+
+        assert_eq!(
+            "Success",
+            last_run_status,
+            "{}job '{}' owned by {} for '{}.{}' last run has status {}",
+            self.name(),
+            proc_name.as_ref(),
+            owner.as_ref(),
+            schema.as_ref(),
+            table.as_ref(),
+            last_run_status,
+        );
+
+        self
+    }
+
+    pub fn has_cagg_with_watermark<T: AsRef<str>>(
+        &mut self,
+        schema: T,
+        name: T,
+        watermark: i64,
+    ) -> &mut Self {
+        assert!(
+            self._has_cagg(schema.as_ref(), name.as_ref()).unwrap(),
+            "{}cagg '{}.{}' doesn't exist",
+            self.name(),
+            schema.as_ref(),
+            name.as_ref(),
+        );
+        assert_eq!(
+            watermark,
+            self._fetch_cagg_watermark(schema.as_ref(), name.as_ref())
+                .unwrap(),
+            "{}cagg '{}.{}' watermark mismatch",
+            self.name(),
+            schema.as_ref(),
+            name.as_ref(),
+        );
+        self
+    }
+
+    pub fn has_telemetry<F>(&mut self, asserts: Vec<F>) -> &mut Self
+    where
+        F: Fn(JsonAssert),
+    {
+        let rows = self._get_telemetry().unwrap();
+
+        assert_eq!(
+            asserts.len(),
+            rows.len(),
+            "expected {} telemetry items, got {}",
+            asserts.len(),
+            rows.len()
+        );
+
+        for (idx, row) in rows.iter().enumerate() {
+            let telemetry_raw: Value = row.get(0);
+            let telemetry = telemetry_raw.as_object().unwrap();
+            let assert_fn = asserts.get(idx).unwrap();
+            assert_fn(JsonAssert::new(telemetry));
+        }
+        self
+    }
+
+    pub fn has_index_count<T: AsRef<str>>(
+        &mut self,
+        schema: T,
+        indexed_relname: T,
+        columns: &[T],
+        count: usize,
+    ) -> &mut Self {
+        let columns: Vec<&str> = columns.iter().map(|i| i.as_ref()).collect();
+        let actual_count = self
+            ._get_index_count(schema.as_ref(), indexed_relname.as_ref(), &columns)
+            .unwrap();
+        assert_eq!(
+            actual_count,
+            count,
+            "{}index count on '{}.{}' ({}) is {actual_count}, not {count}",
+            self.name(),
+            schema.as_ref(),
+            indexed_relname.as_ref(),
+            columns.join(", ")
+        );
+        self
+    }
+
+    pub fn has_pk<T: AsRef<str>>(
+        &mut self,
+        table_schema: T,
+        table_name: T,
+        columns: Vec<T>,
+    ) -> &mut Self {
+        let columns: Vec<&str> = columns.iter().map(|c| c.as_ref()).collect();
+        assert!(
+            self._has_pk(table_schema.as_ref(), table_name.as_ref(), &columns)
+                .unwrap(),
+            "{}table '{}.{}' doesn't have a primary key with columns {}",
+            self.name(),
+            table_schema.as_ref(),
+            table_name.as_ref(),
+            columns.join(", "),
+        );
+        self
+    }
+
+    pub fn not_has_pk<T: AsRef<str>>(
+        &mut self,
+        table_schema: T,
+        table_name: T,
+        columns: Vec<T>,
+    ) -> &mut Self {
+        let columns: Vec<&str> = columns.iter().map(|c| c.as_ref()).collect();
+        assert!(
+            !self
+                ._has_pk(table_schema.as_ref(), table_name.as_ref(), &columns)
+                .unwrap(),
+            "{}table '{}.{}' has a primary key with columns {}",
+            self.name(),
+            table_schema.as_ref(),
+            table_name.as_ref(),
+            columns.join(", "),
+        );
+        self
+    }
+    pub fn has_unique_constraint<T: AsRef<str>>(
+        &mut self,
+        table_schema: T,
+        table_name: T,
+        columns: Vec<T>,
+    ) -> &mut Self {
+        let columns: Vec<&str> = columns.iter().map(|c| c.as_ref()).collect();
+        assert!(
+            self._has_unique_constraint(table_schema.as_ref(), table_name.as_ref(), &columns)
+                .unwrap(),
+            "{}table '{}.{}' doesn't have a unique constraint with columns {}",
+            self.name(),
+            table_schema.as_ref(),
+            table_name.as_ref(),
+            columns.join(", "),
+        );
+        self
+    }
+
+    pub fn not_has_unique_constraint<T: AsRef<str>>(
+        &mut self,
+        table_schema: T,
+        table_name: T,
+        columns: Vec<T>,
+    ) -> &mut Self {
+        let columns: Vec<&str> = columns.iter().map(|c| c.as_ref()).collect();
+        assert!(
+            !self
+                ._has_unique_constraint(table_schema.as_ref(), table_name.as_ref(), &columns)
+                .unwrap(),
+            "{}table '{}.{}' has a unique constraint with columns {}",
+            self.name(),
+            table_schema.as_ref(),
+            table_name.as_ref(),
+            columns.join(", "),
+        );
+        self
+    }
+
+    pub fn has_unique_index<T: AsRef<str>>(
+        &mut self,
+        table_schema: T,
+        table_name: T,
+        columns: Vec<T>,
+    ) -> &mut Self {
+        let columns: Vec<&str> = columns.iter().map(|c| c.as_ref()).collect();
+        assert!(
+            self._has_unique_index(table_schema.as_ref(), table_name.as_ref(), &columns)
+                .unwrap(),
+            "{}table '{}.{}' doesn't have a unique index with columns {}",
+            self.name(),
+            table_schema.as_ref(),
+            table_name.as_ref(),
+            columns.join(", "),
+        );
+        self
+    }
+
+    pub fn not_has_unique_index<T: AsRef<str>>(
+        &mut self,
+        table_schema: T,
+        table_name: T,
+        columns: Vec<T>,
+    ) -> &mut Self {
+        let columns: Vec<&str> = columns.iter().map(|c| c.as_ref()).collect();
+        assert!(
+            !self
+                ._has_unique_index(table_schema.as_ref(), table_name.as_ref(), &columns)
+                .unwrap(),
+            "{}table '{}.{}' has a unique index with columns {}",
+            self.name(),
+            table_schema.as_ref(),
+            table_name.as_ref(),
+            columns.join(", "),
+        );
+        self
+    }
+
+    pub fn has_fk<T: AsRef<str>>(
+        &mut self,
+        referencing_schema: T,
+        referencing_name: T,
+        referencing_columns: Vec<T>,
+        referenced_schema: T,
+        referenced_name: T,
+        referenced_columns: Vec<T>,
+    ) -> &mut Self {
+        let referencing_columns: Vec<&str> =
+            referencing_columns.iter().map(|c| c.as_ref()).collect();
+        let referenced_columns: Vec<&str> = referenced_columns.iter().map(|c| c.as_ref()).collect();
+        assert!(
+            self._has_fk(
+                referencing_schema.as_ref(),
+                referencing_name.as_ref(),
+                &referencing_columns,
+                referenced_schema.as_ref(),
+                referenced_name.as_ref(),
+                &referenced_columns
+            )
+            .unwrap(),
+            "{}table '{}.{}' doesn't have a foreign key with columns {} to '{}.{}' on columns {}",
+            self.name(),
+            referencing_schema.as_ref(),
+            referencing_name.as_ref(),
+            referencing_columns.join(", "),
+            referenced_schema.as_ref(),
+            referenced_name.as_ref(),
+            referenced_columns.join(", ")
+        );
+
+        self
+    }
+
+    pub fn not_has_fk<T: AsRef<str>>(
+        &mut self,
+        referencing_schema: T,
+        referencing_name: T,
+        referencing_columns: Vec<T>,
+        referenced_schema: T,
+        referenced_name: T,
+        referenced_columns: Vec<T>,
+    ) -> &mut Self {
+        let referencing_columns: Vec<&str> =
+            referencing_columns.iter().map(|c| c.as_ref()).collect();
+        let referenced_columns: Vec<&str> = referenced_columns.iter().map(|c| c.as_ref()).collect();
+        assert!(
+            !self
+                ._has_fk(
+                    referencing_schema.as_ref(),
+                    referencing_name.as_ref(),
+                    &referencing_columns,
+                    referenced_schema.as_ref(),
+                    referenced_name.as_ref(),
+                    &referenced_columns
+                )
+                .unwrap(),
+            "{}table '{}.{}' has a foreign key with columns {} to '{}.{}' on columns {}",
+            self.name(),
+            referencing_schema.as_ref(),
+            referencing_name.as_ref(),
+            referencing_columns.join(", "),
+            referenced_schema.as_ref(),
+            referenced_name.as_ref(),
+            referenced_columns.join(", ")
+        );
+
+        self
+    }
+
+    pub fn has_uuid(&mut self, uuid: &str) -> &mut Self {
+        let actual_uuid = self._fetch_uuid().unwrap();
+        assert_eq!(
+            uuid,
+            actual_uuid,
+            "{} expected uuid {}, got {}",
+            self.name(),
+            uuid,
+            actual_uuid,
+        );
+        self
+    }
+
+    fn name(&self) -> String {
+        self.name
+            .as_ref()
+            .map(|n| format!("{n}: "))
+            .unwrap_or_default()
+    }
+
+    fn _get_job_id(&mut self, schema: &str, name: &str, proc_name: &str, owner: &str) -> i32 {
+        let query = "\
+SELECT id
+FROM timescaledb_information.job_stats s
+JOIN _timescaledb_config.bgw_job j ON s.job_id = j.id
+WHERE
+  s.hypertable_schema = $1
+  AND s.hypertable_name = $2
+  AND j.proc_name = $3
+  AND j.owner::text = $4
+";
+
+        let row = self
+            .connection()
+            .query_one(query, &[&schema, &name, &proc_name, &owner])
+            .unwrap();
+        row.get(0)
+    }
+
+    fn _last_run_status(&mut self, job_id: i32) -> String {
+        let query = "\
+SELECT last_run_status
+FROM timescaledb_information.job_stats s
+WHERE
+  job_id = $1
+";
+
+        let row = self.connection().query_one(query, &[&job_id]).unwrap();
+        row.get(0)
+    }
+
+    fn _is_true(&mut self, query: &str) -> bool {
+        let client = self.connection();
+        let v: bool = client.query_one(query, &[]).unwrap().get(0);
+        v
+    }
+
+    fn _has_job(
+        &mut self,
+        schema: Option<&str>,
+        name: Option<&str>,
+        proc_name: &str,
+    ) -> Result<bool> {
+        let query = "\
+SELECT EXISTS (
+  SELECT 1
+  FROM timescaledb_information.jobs j
+  WHERE
+    CASE WHEN $1::text IS NULL THEN j.hypertable_schema IS NULL ELSE j.hypertable_schema = $1 END
+    AND CASE WHEN $2::text IS NULL THEN j.hypertable_name IS NULL ELSE j.hypertable_name = $2 END
+    AND j.proc_name = $3
+);";
+
+        let row = self
+            .connection()
+            .query_one(query, &[&schema, &name, &proc_name])
+            .unwrap();
+        Ok(row.get(0))
+    }
+
+    fn _has_job_owner(
+        &mut self,
+        schema: Option<&str>,
+        name: Option<&str>,
+        proc_name: &str,
+        owner: &str,
+    ) -> Result<bool> {
+        let query = "\
+SELECT EXISTS (
+  SELECT 1
+  FROM timescaledb_information.jobs j
+  WHERE
+    CASE WHEN $1::text IS NULL THEN j.hypertable_schema IS NULL ELSE j.hypertable_schema = $1 END
+    AND CASE WHEN $2::text IS NULL THEN j.hypertable_name IS NULL ELSE j.hypertable_name = $2 END
+    AND j.proc_name = $3
+    AND j.owner::text = $4
+);";
+
+        let row = self
+            .connection()
+            .query_one(query, &[&schema, &name, &proc_name, &owner])
+            .unwrap();
+        Ok(row.get(0))
+    }
+
+    fn _has_job_scheduled(
+        &mut self,
+        schema: &str,
+        name: &str,
+        proc_name: &str,
+        owner: &str,
+    ) -> Result<bool> {
+        let query = "\
+SELECT EXISTS (
+  SELECT 1
+  FROM timescaledb_information.jobs j
+  WHERE
+    j.scheduled
+    AND j.next_start IS NOT NULL
+    AND j.hypertable_schema = $1
+    AND j.hypertable_name = $2
+    AND j.proc_name = $3
+    AND j.owner::text = $4
+);";
+
+        let row = self
+            .connection()
+            .query_one(query, &[&schema, &name, &proc_name, &owner])
+            .unwrap();
+        Ok(row.get(0))
+    }
+
+    fn _has_schema(&mut self, schema: &str) -> Result<bool> {
+        let row = self.connection().query_one(
+            "SELECT EXISTS (SELECT true FROM pg_namespace WHERE nspname = $1);",
+            &[&schema],
+        )?;
+        Ok(row.get(0))
+    }
+
+    fn _has_table(&mut self, schema: &str, table: &str) -> Result<bool> {
+        let row = self.connection().query_one(
+            "SELECT EXISTS (SELECT true FROM pg_tables WHERE schemaname = $1 AND tablename = $2);",
+            &[&schema, &table],
+        )?;
+        Ok(row.get(0))
+    }
+
+    fn _has_fk_constraint_named(&mut self, fk_constraint_name: &str) -> Result<bool> {
+        let row = self.connection().query_one(
+            "SELECT EXISTS (SELECT true FROM pg_constraint WHERE contype = 'f' AND conname = $1);",
+            &[&fk_constraint_name],
+        )?;
+        Ok(row.get(0))
+    }
+
+    fn _has_hypertable(&mut self, schema: &str, table: &str) -> Result<bool> {
+        if self
+            ._get_installed_extension_version("timescaledb")?
+            .is_none()
+        {
+            return Ok(false);
+        }
+        let row = self.connection().query_one(
+           "SELECT EXISTS (SELECT true FROM _timescaledb_catalog.hypertable WHERE schema_name = $1 and table_name = $2)",
+         &[&schema, &table])?;
+        Ok(row.get(0))
+    }
+
+    fn _has_sequence(&mut self, schema: &str, sequence: &str) -> Result<bool> {
+        let row = self.connection().query_one(
+            "SELECT EXISTS (SELECT true FROM pg_sequences WHERE schemaname = $1 AND sequencename = $2);",
+            &[&schema, &sequence],
+        )?;
+        Ok(row.get(0))
+    }
+
+    fn _sequence_value(&mut self, schema: &str, sequence: &str) -> Result<Option<i64>> {
+        let row = self.connection().query_one(
+            "SELECT pg_sequence_last_value((SELECT format('%I.%I', $1::text, $2::text)))",
+            &[&schema, &sequence],
+        )?;
+        Ok(row.get(0))
+    }
+
+    fn _get_installed_extension_version(&mut self, extension: &str) -> Result<Option<String>> {
+        let result = self.connection().query_opt(
+            "SELECT extversion FROM pg_extension WHERE extname = $1",
+            &[&extension],
+        )?;
+        Ok(result.map(|row| row.get::<_, String>(0)))
+    }
+
+    fn _get_table_count(&mut self, schema: &str, table: &str) -> Result<i64> {
+        let row = self.connection().query_one(
+            &format!(
+                r#"
+            SELECT count(*) FROM "{schema}"."{table}""#
+            ),
+            &[],
+        )?;
+        Ok(row.get("count"))
+    }
+
+    fn _get_chunk_count(&mut self, schema: &str, table: &str) -> Result<i64> {
+        let row = self.connection().query_one(
+            r#"
+            SELECT count(*) FROM _timescaledb_catalog.chunk c
+            JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id
+            WHERE h.schema_name = $1
+              AND h.table_name = $2"#,
+            &[&schema, &table],
+        )?;
+        Ok(row.get("count"))
+    }
+
+    fn _get_task_count(&mut self) -> Result<i64> {
+        let row = self
+            .connection()
+            .query_one("SELECT count(*) FROM __backfill.task", &[])?;
+        Ok(row.get("count"))
+    }
+
+    fn _get_task_count_for_table(&mut self, schema: &str, table: &str) -> Result<i64> {
+        let row = self.connection().query_one(
+            r#"
+            SELECT count(*)
+            FROM __backfill.task t
+            WHERE (t.hypertable_schema, t.hypertable_name) IN
+            (
+                SELECT
+                  $1 as hypertable_schema
+                , $2 as hypertable_table
+                UNION
+                SELECT
+                  h.schema_name
+                , h.table_name
+                FROM _timescaledb_catalog.continuous_agg c
+                INNER JOIN _timescaledb_catalog.hypertable h ON (h.id = c.mat_hypertable_id)
+                WHERE c.user_view_schema = $1
+                AND c.user_view_name = $2
+            )"#,
+            &[&schema, &table],
+        )?;
+        Ok(row.get("count"))
+    }
+
+    fn _get_compressed_chunk_count(&mut self, schema: &str, table: &str) -> Result<i64> {
+        let row = self.connection().query_one(
+            r#"
+            SELECT count(*) FROM timescaledb_information.chunks
+            WHERE hypertable_schema = $1
+              AND hypertable_name = $2
+              AND is_compressed = true"#,
+            &[&schema, &table],
+        )?;
+        Ok(row.get("count"))
+    }
+
+    fn _get_cagg_materialized_table(
+        &mut self,
+        schema: &str,
+        table: &str,
+    ) -> Result<(String, String)> {
+        let row = self.connection().query_one(
+            r"
+            SELECT
+              materialization_hypertable_schema as mt_schema
+            , materialization_hypertable_name as mt_name
+            FROM timescaledb_information.continuous_aggregates
+            WHERE view_schema = $1
+              AND view_name = $2
+        ",
+            &[&schema, &table],
+        )?;
+        let mt_schema = row.get("mt_schema");
+        let mt_name = row.get("mt_name");
+        Ok((mt_schema, mt_name))
+    }
+
+    fn _has_cagg(&mut self, schema: &str, name: &str) -> Result<bool> {
+        let query: &str = r"SELECT EXISTS (
+            SELECT true
+            FROM _timescaledb_catalog.continuous_agg
+            WHERE user_view_schema = $1 AND user_view_name = $2)";
+        let row = self.connection().query_one(query, &[&schema, &name])?;
+        Ok(row.get(0))
+    }
+
+    // TODO add support for the old format
+    fn _fetch_cagg_watermark(&mut self, schema: &str, name: &str) -> Result<i64> {
+        let query: &str = r"SELECT watermark
+            FROM _timescaledb_catalog.continuous_agg
+            JOIN _timescaledb_catalog.continuous_aggs_watermark USING (mat_hypertable_id)
+            WHERE user_view_schema = $1 AND user_view_name = $2";
+        let row = self.connection().query_one(query, &[&schema, &name])?;
+        Ok(row.get(0))
+    }
+
+    fn _get_telemetry(&mut self) -> Result<Vec<Row>> {
+        let rows = self.connection().query(
+            r"
+            SELECT body
+            FROM _timescaledb_catalog.telemetry_event
+            WHERE tag = 'timescaledb-backfill'
+            ORDER BY created
+        ",
+            &[],
+        )?;
+        Ok(rows)
+    }
+
+    fn _get_index_count(&mut self, schema: &str, relname: &str, columns: &[&str]) -> Result<usize> {
+        let query: &str = r"
+          select
+            count(*)
+          from
+            pg_class cls
+          join
+            pg_namespace n on n.oid = cls.relnamespace
+          join
+            pg_index i on i.indrelid = cls.oid
+          join lateral (
+            select
+              array_agg(attname::text order by key.pos) as names
+            from
+              pg_attribute a
+            join
+              unnest(i.indkey::oid[]) with ordinality as key(attnum, pos) on key.attnum = a.attnum
+            where
+              cls.oid = a.attrelid
+          ) as columns on (true)
+          where
+            n.nspname = $1
+            and cls.relname = $2
+            and columns.names = $3
+        ";
+
+        let row = self
+            .connection()
+            .query_one(query, &[&schema, &relname, &columns])?;
+        Ok(row.get::<'_, _, i64>(0) as usize)
+    }
+
+    fn _has_pk(
+        &mut self,
+        table_schema: &str,
+        table_name: &str,
+        columns: &Vec<&str>,
+    ) -> Result<bool> {
+        self._has_constraint(table_schema, table_name, columns, "p")
+    }
+
+    fn _has_unique_constraint(
+        &mut self,
+        table_schema: &str,
+        table_name: &str,
+        columns: &Vec<&str>,
+    ) -> Result<bool> {
+        self._has_constraint(table_schema, table_name, columns, "u")
+    }
+
+    fn _has_constraint(
+        &mut self,
+        table_schema: &str,
+        table_name: &str,
+        columns: &Vec<&str>,
+        constraint_type: &str,
+    ) -> Result<bool> {
+        let query: &str = r"select exists (
+        select
+        from
+          pg_class cls
+        join
+          pg_namespace n on n.oid = cls.relnamespace
+        join
+          pg_constraint c on c.conrelid = cls.oid
+        join lateral (
+          select
+            array_agg(attname::text order by key.pos) as names
+          from
+            pg_attribute a
+          join
+            unnest(c.conkey) with ordinality as key(attnum, pos) on key.attnum = a.attnum
+          where
+            cls.oid = a.attrelid
+        ) as columns on (true)
+        where
+          n.nspname = $1
+          and cls.relname = $2
+          and columns.names = $3
+          and c.contype = $4::char
+        )";
+
+        let row = self.connection().query_one(
+            query,
+            &[&table_schema, &table_name, &columns, &constraint_type],
+        )?;
+        Ok(row.get(0))
+    }
+
+    fn _has_unique_index(
+        &mut self,
+        table_schema: &str,
+        table_name: &str,
+        columns: &Vec<&str>,
+    ) -> Result<bool> {
+        let query: &str = r"select exists (
+        select
+        from
+          pg_class cls
+        join
+          pg_namespace n on n.oid = cls.relnamespace
+        join
+          pg_index i on i.indrelid = cls.oid
+        join lateral (
+          select
+            array_agg(attname::text order by key.pos) as names
+          from
+            pg_attribute a
+          join
+            unnest(i.indkey::oid[]) with ordinality as key(attnum, pos) on key.attnum = a.attnum
+          where
+            cls.oid = a.attrelid
+        ) as columns on (true)
+        where
+          n.nspname = $1
+          and cls.relname = $2
+          and i.indisunique is true
+          and columns.names = $3
+        )";
+
+        let row = self
+            .connection()
+            .query_one(query, &[&table_schema, &table_name, &columns])?;
+        Ok(row.get(0))
+    }
+
+    fn _has_fk(
+        &mut self,
+        referencing_schema: &str,
+        referencing_name: &str,
+        referencing_columns: &Vec<&str>,
+        referenced_schema: &str,
+        referenced_name: &str,
+        referenced_columns: &Vec<&str>,
+    ) -> Result<bool> {
+        let query: &str = r"select exists (
+        select
+        from
+          pg_class referencing_cls
+        join
+          pg_namespace referencing_n on referencing_n.oid = referencing_cls.relnamespace
+        join
+          pg_constraint c on c.conrelid = referencing_cls.oid
+        join
+          pg_class referenced_cls on c.confrelid = referenced_cls.oid
+        join
+          pg_namespace referenced_n on referenced_n.oid = referenced_cls.relnamespace
+        join lateral (
+          select
+            array_agg(attname::text order by key.pos) as names
+          from
+            pg_attribute a
+          join
+            unnest(c.conkey) with ordinality as key(attnum, pos) on key.attnum = a.attnum
+          where
+            referencing_cls.oid = a.attrelid
+        ) as referencing_columns on (true)
+        join lateral (
+          select
+            array_agg(attname::text order by key.pos) as names
+          from
+            pg_attribute a
+          join
+            unnest(c.conkey) with ordinality as key(attnum, pos) on key.attnum = a.attnum
+          where
+            referenced_cls.oid = a.attrelid
+        ) as referenced_columns on (true)
+        where
+          referencing_n.nspname = $1
+          and referencing_cls.relname = $2
+          and referencing_columns.names = $3
+          and c.contype = 'f'
+          and referenced_n.nspname = $4
+          and referenced_cls.relname = $5
+          and referenced_columns.names = $6
+        )";
+
+        let row = self.connection().query_one(
+            query,
+            &[
+                &referencing_schema,
+                &referencing_name,
+                &referencing_columns,
+                &referenced_schema,
+                &referenced_name,
+                &referenced_columns,
+            ],
+        )?;
+        Ok(row.get(0))
+    }
+
+    fn _fetch_uuid(&mut self) -> Result<String> {
+        let row = self.connection().query_one(
+            r"
+SELECT value as uuid
+FROM _timescaledb_catalog.metadata
+WHERE key = 'uuid'
+LIMIT 1
+              ",
+            &[],
+        )?;
+        Ok(row.get("uuid"))
+    }
+}

--- a/test-common/src/json_assert.rs
+++ b/test-common/src/json_assert.rs
@@ -1,0 +1,65 @@
+use serde_json::{Map, Value};
+use std::fmt::Debug;
+
+use crate::assert_within;
+
+pub struct JsonAssert<'a> {
+    inner: &'a Map<String, Value>,
+}
+
+impl<'a> JsonAssert<'a> {
+    pub fn new(json_map: &'a Map<String, Value>) -> Self {
+        Self { inner: json_map }
+    }
+
+    pub fn has<T>(&self, key: &str, value: T)
+    where
+        T: PartialEq + Debug,
+        Value: PartialEq<T>,
+    {
+        let is_value = self.inner.get(key).unwrap();
+        assert!(
+            is_value.eq(&value),
+            "key '{key}' is: {is_value:?}, want: {value:?}"
+        );
+    }
+
+    pub fn has_array_value<T>(&self, key: &str, value: Vec<T>)
+    where
+        T: PartialEq + Debug,
+        Value: PartialEq<T>,
+    {
+        let is_value = self.inner.get(key).unwrap().as_array().unwrap();
+        assert!(
+            is_value.eq(&value),
+            "key '{key}' is: {is_value:?}, want: {value:?}"
+        );
+    }
+
+    pub fn has_null(&self, key: &str) {
+        let value = self.inner.get(key).unwrap();
+        assert!(value.is_null(), "{} is not null", key);
+    }
+
+    pub fn has_string(&self, key: &str) {
+        let value = self.inner.get(key).unwrap();
+        assert!(value.is_string(), "{} is not a string", key);
+    }
+
+    pub fn has_number(&self, key: &str) {
+        let value = self.inner.get(key).unwrap();
+        assert!(value.is_number(), "{} is not a numver", key);
+    }
+
+    pub fn has_number_within<T, U>(&self, key: &str, value: T, tolerance: U)
+    where
+        T: Into<f64>,
+        U: Into<f64>,
+    {
+        let value: f64 = value.into();
+        let tolerance: f64 = tolerance.into();
+        let is_value = self.inner.get(key).unwrap().as_f64().unwrap();
+
+        assert_within!(value, is_value, tolerance);
+    }
+}

--- a/test-common/src/lib.rs
+++ b/test-common/src/lib.rs
@@ -1,0 +1,27 @@
+use postgres::{Config, NoTls};
+use std::str::FromStr;
+
+mod assert_within;
+mod cloud;
+mod db_assert;
+mod json_assert;
+mod psql;
+mod test_connection_string;
+mod timescale_docker;
+
+pub use crate::cloud::*;
+pub use crate::db_assert::*;
+pub use crate::json_assert::*;
+pub use crate::psql::*;
+pub use crate::test_connection_string::*;
+pub use crate::timescale_docker::*;
+
+pub fn get_ts_version(dsn: &TestConnectionString) -> Result<String, tokio_postgres::Error> {
+    let config = Config::from_str(dsn.connection_string().as_str())?;
+    let mut client = config.connect(NoTls)?;
+    let row = client.query_one(
+        "SELECT extversion FROM pg_extension WHERE extname = 'timescaledb'",
+        &[],
+    )?;
+    Ok(row.get(0))
+}

--- a/test-common/src/lib.rs
+++ b/test-common/src/lib.rs
@@ -25,3 +25,21 @@ pub fn get_ts_version(dsn: &TestConnectionString) -> Result<String, tokio_postgr
     )?;
     Ok(row.get(0))
 }
+
+/// Whether `_timescaledb_catalog.chunk` still has the `dropped` column. It was
+/// removed in TimescaleDB 2.26. Detecting the column is more robust than a
+/// version check, which is awkward for nightly prerelease versions.
+pub fn chunk_has_dropped_column(dsn: &TestConnectionString) -> Result<bool, tokio_postgres::Error> {
+    let config = Config::from_str(dsn.connection_string().as_str())?;
+    let mut client = config.connect(NoTls)?;
+    let row = client.query_one(
+        "SELECT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = '_timescaledb_catalog'
+              AND table_name = 'chunk'
+              AND column_name = 'dropped'
+        )",
+        &[],
+    )?;
+    Ok(row.get(0))
+}

--- a/test-common/src/psql.rs
+++ b/test-common/src/psql.rs
@@ -1,0 +1,74 @@
+use std::ffi::OsStr;
+use std::iter;
+use std::process::Command;
+use thiserror::Error;
+
+use crate::*;
+
+#[derive(Debug, Error)]
+pub enum PsqlError {
+    #[error("spawn failed")]
+    SpawnFailed(#[from] std::io::Error),
+    #[error("psql error: {0}")]
+    CommandFailed(String),
+}
+
+#[derive(Debug)]
+pub enum PsqlInput<S: AsRef<OsStr>> {
+    File(S),
+    Sql(S),
+}
+
+impl<S: AsRef<OsStr>> IntoIterator for PsqlInput<S> {
+    type Item = PsqlInput<S>;
+
+    type IntoIter = iter::Once<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
+    }
+}
+
+/// Launches a `psql` terminal-based front-end to PostgreSQL using
+/// `has_url` to derive a connection string and executes SQL from `inputs`.
+/// `inputs` can be any [`IntoIterator`] collection of [`PsqlInput`] elements:
+///  - [`PsqlInput::File`] can be used to supply psql scripts and
+///    is translated into `-f` flag
+///  - [`PsqlInput::Sql`] is better suited for short SQL statements and
+///    corresponds to `-C` flag.
+///
+/// If `PSQL_DOCKER` environment variable is set to `true` psql is be launched
+/// inside a docker container using [`PSQL_IMAGE`]. The crate's root is mounted
+/// as `/media` and set as a working directory, preserving relative paths.
+pub fn psql<C: HasConnectionString, S: AsRef<OsStr>, I: IntoIterator<Item = PsqlInput<S>>>(
+    has_url: &C,
+    inputs: I,
+) -> Result<(), PsqlError> {
+    let inputs_vec = inputs.into_iter().collect::<Vec<PsqlInput<S>>>();
+    let input_args = inputs_vec
+        .iter()
+        .flat_map(|input| match input {
+            PsqlInput::File(file) => ["-f", file.as_ref().to_str().unwrap()],
+            PsqlInput::Sql(sql) => ["-c", sql.as_ref().to_str().unwrap()],
+        })
+        .collect::<Vec<&str>>();
+
+    let mut base_cmd = Command::new("psql");
+
+    let output = base_cmd
+        .arg("-AtXq")
+        .arg("--set")
+        .arg("ON_ERROR_STOP=1")
+        .arg("-d")
+        .arg(has_url.connection_string())
+        .args(input_args)
+        .output()?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(PsqlError::CommandFailed(
+            String::from_utf8(output.stderr).unwrap(),
+        ))
+    }
+}

--- a/test-common/src/test_connection_string.rs
+++ b/test-common/src/test_connection_string.rs
@@ -1,0 +1,191 @@
+use std::{ffi::OsStr, str::FromStr};
+use testcontainers::Container;
+
+use tokio_postgres::Config as PgConfig;
+
+// Note: do not be tempted to replace this with "localhost".
+// If you do, everything will work perfectly fine, except for occasional CI
+// failures which you can't really explain, and spend weeks tracking down.
+// The reason is that docker exposes the database's internal ports on both the
+// ipv4 and ipv6 addresses of the host. There can be "overlap" in that the same
+// port number is mapped for ipv4 and ipv6, but the ports belong to different
+// containers. If the connection to the database uses "localhost", it can be
+// (depending on the host's setup) that this resolves to the ipv6 address. By
+// hard-coding the ipv4 loopback address, we ensure that we're always talking
+// to the container that we think we are.
+static LOOPBACK_IPV4_ADDRESS: &str = "127.0.0.1";
+
+#[derive(Clone, Debug)]
+struct TestConnectionParts {
+    user: Option<String>,
+    host: Option<String>,
+    port: Option<u16>,
+    dbname: Option<String>,
+    password: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct TestConnectionString {
+    internal: TestConnectionParts,
+    formatted: String,
+}
+
+impl Default for TestConnectionString {
+    fn default() -> Self {
+        TestConnectionString::new(5432)
+    }
+}
+
+impl TestConnectionString {
+    #[allow(clippy::single_char_pattern)]
+    fn escape_conn_value(value: &str) -> String {
+        value.replace(r"\", r"\\").replace(r"'", r"\'")
+    }
+
+    fn build(internal: TestConnectionParts) -> Self {
+        // this structure should enable us to add support
+        // for more fields as we begin to require them
+        let components = vec![
+            internal
+                .user
+                .as_ref()
+                .map(|v| format!("user='{}'", Self::escape_conn_value(v))),
+            internal
+                .host
+                .as_ref()
+                .map(|v| format!("host='{}'", Self::escape_conn_value(v))),
+            internal.port.map(|v| format!("port={v}")),
+            internal
+                .dbname
+                .as_ref()
+                .map(|v| format!("dbname='{}'", Self::escape_conn_value(v))),
+            internal
+                .password
+                .as_ref()
+                .map(|v| format!("password='{}'", Self::escape_conn_value(v))),
+        ];
+        let formatted = components
+            .into_iter()
+            .map(|f| f.unwrap_or_else(|| "".into()) + " ")
+            .collect();
+        Self {
+            internal,
+            formatted,
+        }
+    }
+
+    pub fn is_localhost(&self) -> bool {
+        self.internal
+            .host
+            .as_ref()
+            .map(|h| h == "localhost" || h == "127.0.0.1")
+            .unwrap_or(false)
+    }
+
+    pub fn new(port: u16) -> Self {
+        Self::build(TestConnectionParts {
+            dbname: Some("postgres".into()),
+            user: Some("postgres".into()),
+            host: Some(LOOPBACK_IPV4_ADDRESS.into()),
+            port: Some(port),
+            password: None,
+        })
+    }
+
+    pub fn dbname(&self, dbname: &str) -> Self {
+        Self::build(TestConnectionParts {
+            dbname: Some(dbname.into()),
+            ..self.internal.clone()
+        })
+    }
+
+    pub fn user(&self, user: &str) -> Self {
+        Self::build(TestConnectionParts {
+            user: Some(user.into()),
+            ..self.internal.clone()
+        })
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.formatted.as_str()
+    }
+}
+
+impl FromStr for TestConnectionString {
+    type Err = tokio_postgres::error::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        PgConfig::from_str(s)
+            .map(|conf| TestConnectionParts {
+                user: conf.get_user().map(|v| v.to_string()),
+                host: conf.get_hosts().first().map(|h| {
+                    let v: &str = match h {
+                        tokio_postgres::config::Host::Tcp(ref addr) => addr.as_ref(),
+                        tokio_postgres::config::Host::Unix(path) => {
+                            path.as_os_str().to_str().unwrap()
+                        }
+                    };
+                    v.to_string()
+                }),
+                port: conf.get_ports().first().copied(),
+                dbname: conf.get_dbname().map(|v| v.to_string()),
+                password: conf
+                    .get_password()
+                    .map(|v| std::str::from_utf8(v).unwrap().to_string()),
+            })
+            .map(TestConnectionString::build)
+    }
+}
+
+impl AsRef<str> for TestConnectionString {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<OsStr> for TestConnectionString {
+    fn as_ref(&self) -> &OsStr {
+        self.formatted.as_ref()
+    }
+}
+
+pub trait HasConnectionString {
+    fn connection_string(&self) -> TestConnectionString;
+}
+
+impl<T: testcontainers::Image> HasConnectionString for Container<'_, T> {
+    fn connection_string(&self) -> TestConnectionString {
+        TestConnectionString::new(self.get_host_port_ipv4(5432))
+    }
+}
+
+pub trait InternalConnectionString {
+    fn internal_connection_string(&self) -> TestConnectionString;
+}
+
+impl<T: testcontainers::Image> InternalConnectionString for Container<'_, T> {
+    fn internal_connection_string(&self) -> TestConnectionString {
+        TestConnectionString::build(TestConnectionParts {
+            user: Some("postgres".into()),
+            host: Some(self.id()[..12].into()),
+            port: Some(5432),
+            dbname: Some("postgres".into()),
+            password: None,
+        })
+    }
+}
+
+impl HasConnectionString for TestConnectionString {
+    fn connection_string(&self) -> TestConnectionString {
+        self.clone()
+    }
+}
+
+impl<C> HasConnectionString for &'_ C
+where
+    C: HasConnectionString,
+{
+    fn connection_string(&self) -> TestConnectionString {
+        (**self).connection_string()
+    }
+}

--- a/test-common/src/timescale_docker.rs
+++ b/test-common/src/timescale_docker.rs
@@ -1,0 +1,135 @@
+use crate::TsVersion::{
+    Nightly, TS216, TS217, TS218, TS219, TS220, TS221, TS222, TS223, TS224, TS225, TS226, TS227,
+    TS228,
+};
+use std::fmt::{Display, Formatter};
+use testcontainers::core::WaitFor;
+use testcontainers::images::generic::GenericImage;
+
+#[allow(dead_code)]
+#[derive(PartialEq, Eq)]
+pub enum PgVersion {
+    PG15,
+    PG16,
+    PG17,
+    PG18,
+}
+
+impl Display for PgVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PgVersion::PG15 => f.write_str("15"),
+            PgVersion::PG16 => f.write_str("16"),
+            PgVersion::PG17 => f.write_str("17"),
+            PgVersion::PG18 => f.write_str("18"),
+        }
+    }
+}
+
+impl<T: AsRef<str>> From<T> for PgVersion {
+    fn from(value: T) -> Self {
+        match value.as_ref() {
+            "15" => PgVersion::PG15,
+            "16" => PgVersion::PG16,
+            "17" => PgVersion::PG17,
+            "18" => PgVersion::PG18,
+            _ => unimplemented!(),
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+pub enum TsVersion {
+    TS216,
+    TS217,
+    TS218,
+    TS219,
+    TS220,
+    TS221,
+    TS222,
+    TS223,
+    TS224,
+    TS225,
+    TS226,
+    TS227,
+    TS228,
+    /// The nightly build of TimescaleDB. Tracks the next unreleased version
+    /// (currently 2.29). Ordered last so it compares greater than any released
+    /// version.
+    Nightly,
+}
+
+impl From<String> for TsVersion {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "2.16" => TS216,
+            "2.17" => TS217,
+            "2.18" => TS218,
+            "2.19" => TS219,
+            "2.20" => TS220,
+            "2.21" => TS221,
+            "2.22" => TS222,
+            "2.23" => TS223,
+            "2.24" => TS224,
+            "2.25" => TS225,
+            "2.26" => TS226,
+            "2.27" => TS227,
+            "2.28" => TS228,
+            "2.29" | "nightly" => Nightly,
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl Display for TsVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TS216 => write!(f, "2.16"),
+            TS217 => write!(f, "2.17"),
+            TS218 => write!(f, "2.18"),
+            TS219 => write!(f, "2.19"),
+            TS220 => write!(f, "2.20"),
+            TS221 => write!(f, "2.21"),
+            TS222 => write!(f, "2.22"),
+            TS223 => write!(f, "2.23"),
+            TS224 => write!(f, "2.24"),
+            TS225 => write!(f, "2.25"),
+            TS226 => write!(f, "2.26"),
+            TS227 => write!(f, "2.27"),
+            TS228 => write!(f, "2.28"),
+            Nightly => write!(f, "2.29"),
+        }
+    }
+}
+
+pub const TIMESCALEDB_IMAGE: &str = "timescale/timescaledb-ha";
+
+/// Nightly builds live in a separate repository and are tagged only by the
+/// PostgreSQL version (e.g. `nightly-pg18`).
+pub const TIMESCALEDB_NIGHTLY_IMAGE: &str = "timescaledev/timescaledb";
+
+/// Prepares a testcontainer image object for a given version of PostgreSQL
+pub fn postgres(version: PgVersion) -> GenericImage {
+    generic_postgres("postgres", version.to_string().as_str())
+}
+
+/// Prepares a testcontainer image object for the latest version of
+/// TimescaleDB and a given version of PostgreSQL
+pub fn timescaledb(pg_version: PgVersion, ts_version: TsVersion) -> GenericImage {
+    let (image, tag) = match ts_version {
+        Nightly => (TIMESCALEDB_NIGHTLY_IMAGE, format!("nightly-pg{pg_version}")),
+        _ => (TIMESCALEDB_IMAGE, format!("pg{pg_version}-ts{ts_version}")),
+    };
+    generic_postgres(image, tag.as_str()).with_env_var("TIMESCALEDB_TELEMETRY", "off")
+}
+
+/// Prepares a testcontainer image object for a given image name and tag
+pub fn generic_postgres(name: &str, tag: &str) -> GenericImage {
+    GenericImage::new(name, tag)
+        .with_exposed_port(5432)
+        .with_env_var("POSTGRES_HOST_AUTH_METHOD", "trust")
+        .with_wait_for(WaitFor::message_on_stderr(
+            "database system is ready to accept connections",
+        ))
+}

--- a/tests/cloud_init.sql
+++ b/tests/cloud_init.sql
@@ -212,6 +212,14 @@ $$;
 -- escalation. Check the trigger is not disabled and is BEFORE ROW INSERT or UPDATE (tgtype controls that) one.
 DO $$
   BEGIN
+    -- In TimescaleDB 2.23+ bgw_job became a view, which cannot have row-level
+    -- triggers, so skip this.
+    IF (SELECT relkind
+        FROM pg_catalog.pg_class
+        WHERE oid = '_timescaledb_config.bgw_job'::regclass) <> 'r'
+    THEN
+      RETURN;
+    END IF;
     IF NOT EXISTS(
         SELECT 1
         FROM pg_catalog.pg_trigger

--- a/tests/cloud_init.sql
+++ b/tests/cloud_init.sql
@@ -290,13 +290,15 @@ DO $$
 
     -- The telemetry events table is intended for application data (like cli tools)
     -- that should be included in telemetry.
-    IF EXISTS (
-      SELECT FROM pg_tables
-      WHERE schemaname = '_timescaledb_catalog'
-        AND tablename = 'telemetry_event'
-    ) THEN
-      GRANT INSERT ON TABLE _timescaledb_catalog.telemetry_event TO tsdbadmin;
-    END IF;
+    -- TimescaleDB removed this catalog table from core around 2.23; Tiger Cloud
+    -- still provisions it (backfill writes telemetry to it), so recreate it here
+    -- to simulate the cloud environment.
+    CREATE TABLE IF NOT EXISTS _timescaledb_catalog.telemetry_event (
+        created timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        tag name NOT NULL,
+        body jsonb NOT NULL
+    );
+    GRANT INSERT ON TABLE _timescaledb_catalog.telemetry_event TO tsdbadmin;
 
     -- We should allow the creation of new chunk tables within the _timescaledb_internal schema using pg_restore.
     -- Although we could implement an event trigger to specifically filter chunk tables, this may be unnecessary since

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -371,6 +371,25 @@ fn configure_cloud_setup<C: HasConnectionString>(container: &C) -> Result<()> {
     Ok(())
 }
 
+/// Tiger Cloud provisions `_timescaledb_catalog.telemetry_event`, which
+/// TimescaleDB removed from core in 2.26. Backfill writes telemetry to this
+/// table (on the target) only when it exists, so tests that assert telemetry
+/// must provision it to exercise the feature on newer versions. On older
+/// versions the table already exists and `IF NOT EXISTS` makes this a no-op.
+fn provision_telemetry_event<C: HasConnectionString>(container: &C) -> Result<()> {
+    psql(
+        &container,
+        PsqlInput::Sql(
+            "CREATE TABLE IF NOT EXISTS _timescaledb_catalog.telemetry_event (
+                created timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                tag name NOT NULL,
+                body jsonb NOT NULL
+            )",
+        ),
+    )?;
+    Ok(())
+}
+
 generate_tests!(
     (
         copy_data_from_chunks,
@@ -1427,6 +1446,7 @@ fn copy_without_available_tasks_error() -> Result<()> {
 
     let source_container = docker.run(timescaledb(pg_version(), ts_version()));
     let target_container = docker.run(timescaledb(pg_version(), ts_version()));
+    provision_telemetry_event(&target_container)?;
 
     run_backfill(TestConfigStage::new(
         &source_container,
@@ -1807,6 +1827,13 @@ fn stage_skips_chunks_marked_as_dropped() -> Result<()> {
     let source_container = docker.run(timescaledb(pg_version(), ts_version()));
     let target_container = docker.run(timescaledb(pg_version(), ts_version()));
 
+    // Dropped-chunk tombstones only exist while the catalog has a `dropped`
+    // column (removed in TS 2.26). Newer versions delete dropped chunks from the
+    // catalog outright, so there is nothing for `stage` to skip.
+    if !chunk_has_dropped_column(&source_container.connection_string())? {
+        return Ok(());
+    }
+
     psql(
         &source_container,
         vec![
@@ -2051,6 +2078,7 @@ fn verify_task_with_extra_rows_in_source() -> Result<()> {
 
     let source_container = docker.run(timescaledb(pg_version(), ts_version()));
     let target_container = docker.run(timescaledb(pg_version(), ts_version()));
+    provision_telemetry_event(&target_container)?;
 
     // Given a chunk that's staged and copied
     stage_and_copy_a_single_chunk(&source_container, &target_container)?;
@@ -2270,6 +2298,7 @@ where
         PsqlInput::File(PathBuf::from("tests/source_schema.sql")),
     )?;
     copy_skeleton_schema(&source_container, &target_container)?;
+    provision_telemetry_event(&target_container)?;
 
     let mut source_dbassert = DbAssert::new(&source_container.connection_string())
         .unwrap()
@@ -2568,6 +2597,7 @@ fn telemetry_captures_error_reason() -> Result<()> {
     psql(&source_container, PsqlInput::Sql(INSERT_DATA_FOR_MAY))?;
 
     copy_skeleton_schema(&source_container, &target_container)?;
+    provision_telemetry_event(&target_container)?;
 
     psql(&target_container, PsqlInput::Sql("drop table metrics"))?;
     psql(


### PR DESCRIPTION
## Why

TimescaleDB 2.29 (currently available only as a nightly build) reworks `_timescaledb_catalog.chunk`, which this tool queries directly. Without changes, `stage`/`copy`/`verify` break against 2.29. Exercising the tool against the latest released versions (up to 2.28) also surfaced pre-existing gaps, since it had never been tested past 2.22.

## What

**Vendor test-common** (was a private git dep used only here) as a path crate in a Cargo workspace, and extend it: TS 2.23–2.28, a `Nightly` (2.29) variant, PG18, and nightly-image support (`timescaledev/timescaledb:nightly-pgNN`).

**Support the 2.29 chunk catalog.** The chunk relation is now a `relid` (regclass) instead of `schema_name`/`table_name`; `compressed_chunk_id` and `dropped` are gone; the compressed relation is reached via `compression_settings.compress_relid` and its size via `compression_chunk_size.chunk_id`. The `dropped`-column removal (2.26) and the `relid` switch (2.29) land at different versions, so the chunk shape is **detected at runtime**, not gated on a version.

Also fixes issues found once run against 2.23–2.29:
- Feature flags used semver comparators a nightly prerelease (`2.29.0-dev`) never matched, silently disabling every feature. The prerelease is now stripped before matching.
- `compression_settings` leaves defaulted arrays (e.g. `orderby`) NULL at the hypertable level in 2.29; tolerate NULL and build/validate compressed chunks from the materialized chunk-level settings.
- The compressed sparse-index metadata moved to `_ts_meta_v2_first_<col>`/`_ts_meta_v2_last_<col>`; the index is built from whichever columns the data table actually has.

**Test harness** (2.26+): provision the Cloud-only `telemetry_event` table (removed from core), guard the `bgw_job` row trigger when it is a view, and skip the dropped-tombstone test where the `dropped` column is gone.

**CI:** add 2.23–2.28 + nightly to the matrix, non-blocking (`continue-on-error`); 2.17–2.22 stay the blocking set.

## Validation

- Manual `stage`/`copy`/`verify` between two nightly (2.29) instances with compression + continuous aggregates: **data matches exactly** (row counts, checksums, cagg rows, compressed chunks recreated and queryable).
- Full integration suite on **2.28**: green except `copy_continuous_aggregates` (see below). Compressed-chunk DDL-parity test passes on both **2.28** and **2.22** (legacy path).
- Unit tests green.

## Known open item

`copy_continuous_aggregates` fails on 2.28+ on a `continuous_aggs_hypertable_invalidation_log` count assertion (5 vs expected 0) — a genuine cagg invalidation-log behavior difference in newer TS, needing a decision on whether the residual entries are expected (adjust the assertion) or should be cleared. Tracked as the reason the new versions are non-blocking in CI.

## Notes

- The nightly image is amd64-only (no arm64 manifest); it runs natively on CI (amd64) but needs `--platform linux/amd64` locally on Apple Silicon.
- The `test-common` changes were originally opened as timescale/test-common#42, now closed in favor of vendoring here.
