### PR TITLE
feat: support TimescaleDB 2.29 (relid chunk catalog) + 2.27/2.28/nightly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,10 +80,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # The latest release of each TimescaleDB minor version running in Tiger
+        # Cloud, plus the nightly (2.29) build.
         pgversion: [17]
-        tsversion: ["2.21", "2.22", "2.23", "2.24", "2.25", "2.26"]
+        tsversion: ["2.22", "2.23", "2.24", "2.25", "2.26", "2.27", "2.28", "nightly"]
 
     runs-on: ubuntu-latest
+    # The nightly build tracks an unreleased version and can break for unrelated
+    # reasons, so it is exercised but non-blocking.
+    continue-on-error: ${{ matrix.tsversion == 'nightly' }}
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,8 +1988,8 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-common"
-version = "0.23.1"
-source = "git+ssh://git@github.com/timescale/test-common.git?rev=v0.23.1#2af856e2dadc134b7df26d97e46dc1f8ceefe296"
+version = "0.24.0"
+source = "git+ssh://git@github.com/timescale/test-common.git?rev=737f8774db26678f9935018f3b7c629b7ef10300#737f8774db26678f9935018f3b7c629b7ef10300"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,7 +1989,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test-common"
 version = "0.24.0"
-source = "git+ssh://git@github.com/timescale/test-common.git?rev=737f8774db26678f9935018f3b7c629b7ef10300#737f8774db26678f9935018f3b7c629b7ef10300"
+source = "git+ssh://git@github.com/timescale/test-common.git?rev=9c8924e#9c8924e3571be7830a87b9686ca2b6c4bc88d95e"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,8 +1988,8 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-common"
-version = "0.24.0"
-source = "git+ssh://git@github.com/timescale/test-common.git?rev=9c8924e#9c8924e3571be7830a87b9686ca2b6c4bc88d95e"
+version = "0.25.0"
+source = "git+ssh://git@github.com/timescale/test-common.git?rev=v0.25.0#327a1f661410715f01f7d1cb19b9958cad8a554f"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,5 +46,5 @@ pretty_env_logger = "0.5.0"
 reqwest = "0.11.22"
 tap-reader = "1.0.1"
 testcontainers = "0.14.0"
-test-common = { git = "ssh://git@github.com/timescale/test-common.git", rev = "9c8924e"}
+test-common = { git = "ssh://git@github.com/timescale/test-common.git", rev = "v0.25.0"}
 strip-ansi-escapes = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,5 +46,5 @@ pretty_env_logger = "0.5.0"
 reqwest = "0.11.22"
 tap-reader = "1.0.1"
 testcontainers = "0.14.0"
-test-common = { git = "ssh://git@github.com/timescale/test-common.git", rev = "737f8774db26678f9935018f3b7c629b7ef10300"}
+test-common = { git = "ssh://git@github.com/timescale/test-common.git", rev = "9c8924e"}
 strip-ansi-escapes = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,5 +46,5 @@ pretty_env_logger = "0.5.0"
 reqwest = "0.11.22"
 tap-reader = "1.0.1"
 testcontainers = "0.14.0"
-test-common = { git = "ssh://git@github.com/timescale/test-common.git", rev = "v0.23.1"}
+test-common = { git = "ssh://git@github.com/timescale/test-common.git", rev = "737f8774db26678f9935018f3b7c629b7ef10300"}
 strip-ansi-escapes = "0.2.0"

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -243,15 +243,20 @@ async fn chunk_status_is_partial(
     target_chunk: &TargetChunk,
 ) -> Result<bool> {
     // Note: status is a bitfield, the 4th bit indicates whether the chunk is partially compressed
-    let row = target_tx
-        .query_one(
-            r"
+    let query = if features::chunk_catalog_uses_relid() {
+        r"
+        SELECT (status & 8)::bool as is_partial
+        FROM _timescaledb_catalog.chunk
+        WHERE relid = to_regclass(format('%I.%I', $1::text, $2::text))"
+    } else {
+        r"
         SELECT (status & 8)::bool as is_partial
         FROM _timescaledb_catalog.chunk
         WHERE schema_name = $1
-          AND table_name = $2",
-            &[&target_chunk.schema, &target_chunk.table],
-        )
+          AND table_name = $2"
+    };
+    let row = target_tx
+        .query_one(query, &[&target_chunk.schema, &target_chunk.table])
         .await?;
     Ok(row.get("is_partial"))
 }
@@ -392,23 +397,31 @@ async fn drop_invalidation_trigger(tx: &Transaction<'_>, chunk_name: &str) -> Re
 
 async fn create_invalidation_trigger(tx: &Transaction<'_>, chunk_name: &str) -> Result<()> {
     debug!("Creating invalidation trigger on '{chunk_name}'");
-    let hypertable_id: i32 = tx
-        .query_one(
-            r"
+    // Note: In the pre-relid catalog there is non-obvious stuff going on here.
+    // The ::text::regclass::text cast dance reformats the relation name to the
+    // database's canonical format. We _explicitly avoid_ casting the left hand
+    // side to regclass, because the _timescaledb_catalog.chunk table contains
+    // entries which refer to non-existent relations. This only happens when the
+    // hypertable has a continuous aggregate on it, and the chunk was dropped.
+    // Casting the non-existent relation to regclass throws an error.
+    //
+    // In the relid catalog (TS >= 2.29) dropped chunks are removed from the
+    // catalog and `relid` is never null, so we can match on it directly.
+    let query = if features::chunk_catalog_uses_relid() {
+        r"
         SELECT hypertable_id
         FROM _timescaledb_catalog.chunk
-        -- Note: There is non-obvious stuff going on here.
-        -- The ::text::regclass::text cast dance reformats the relation name to
-        -- the database's canonical format. We _explicitly avoid_ casting the
-        -- left hand side to regclass, because the _timescaledb_catalog.chunk
-        -- table contains entries which refer to non-existent relations. This
-        -- only happens when the hypertable has a continuous aggregate on it,
-        -- and the chunk was dropped.
-        -- Casting the non-existent relation to regclass throws an error.
+        WHERE relid = $1::text::regclass
+    "
+    } else {
+        r"
+        SELECT hypertable_id
+        FROM _timescaledb_catalog.chunk
         WHERE format('%I.%I', schema_name, table_name)::text = $1::text::regclass::text
-    ",
-            &[&chunk_name],
-        )
+    "
+    };
+    let hypertable_id: i32 = tx
+        .query_one(query, &[&chunk_name])
         .await?
         .get("hypertable_id");
 
@@ -591,9 +604,23 @@ pub async fn get_compressed_chunk(
     source_tx: &Transaction<'_>,
     chunk: &Chunk,
 ) -> Result<Option<SourceCompressedChunk>> {
-    let row = source_tx
-        .query_opt(
-            r#"
+    // In the relid catalog (TS >= 2.29) compressed chunks are no longer chunk
+    // rows. The compressed relation for a chunk is found through
+    // `compression_settings.compress_relid` (only present for compressed
+    // chunks, so an uncompressed chunk yields no row).
+    let query = if features::chunk_catalog_uses_relid() {
+        r#"
+    SELECT
+      n.nspname AS schema_name
+    , cl.relname AS table_name
+    FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = ch.relid
+    JOIN pg_class cl ON cl.oid = cs.compress_relid
+    JOIN pg_namespace n ON n.oid = cl.relnamespace
+    WHERE ch.relid = to_regclass(format('%I.%I', $1::text, $2::text))
+    "#
+    } else {
+        r#"
     SELECT
       cch.schema_name
     , cch.table_name
@@ -601,9 +628,10 @@ pub async fn get_compressed_chunk(
     JOIN _timescaledb_catalog.chunk cch ON ch.compressed_chunk_id = cch.id
     WHERE ch.schema_name = $1
       AND ch.table_name = $2
-    "#,
-            &[&chunk.schema, &chunk.table],
-        )
+    "#
+    };
+    let row = source_tx
+        .query_opt(query, &[&chunk.schema, &chunk.table])
         .await?;
     Ok(row.map(|r| SourceCompressedChunk {
         schema: r.get("schema_name"),
@@ -820,6 +848,17 @@ async fn create_compressed_chunk_index(
         .await;
     }
 
+    // Newer TimescaleDB (~2.28) stores the compressed sparse-index metadata in
+    // `_ts_meta_v2_first_<col>` / `_ts_meta_v2_last_<col>` columns (named after
+    // the orderby column) and indexes those, instead of the older
+    // `_ts_meta_min_<n>` / `_ts_meta_max_<n>` columns (indexed by position).
+    // Some versions keep both column sets, so we detect the v2 columns on the
+    // data table (a copy of the source compressed chunk) rather than gate on a
+    // version, and prefer them to match what TimescaleDB itself builds.
+    let use_v2_metadata = compressed_chunk_uses_v2_metadata(target_tx, qualified_data_table_name)
+        .await
+        .context("failed to detect compressed chunk metadata format")?;
+
     let mut index_columns: Vec<String> = compression_settings
         .segmentby
         .clone()
@@ -827,8 +866,8 @@ async fn create_compressed_chunk_index(
         .map(|c| quote_ident(c))
         .collect();
 
-    // Add min/max columns for orderby settings
-    for (i, _) in compression_settings.orderby.iter().enumerate() {
+    // Add the metadata columns for the orderby settings
+    for (i, orderby_column) in compression_settings.orderby.iter().enumerate() {
         let column_index = i + 1; // 1-based indexing as in C code
         let order_by = if compression_settings.orderby_desc[i] {
             // DESC ordering
@@ -849,10 +888,19 @@ async fn create_compressed_chunk_index(
                 "ASC"
             }
         };
-        let min_column = quote_ident(&format!("_ts_meta_min_{}", column_index));
-        let max_column = quote_ident(&format!("_ts_meta_max_{}", column_index));
-        index_columns.push(format!("{min_column} {order_by}"));
-        index_columns.push(format!("{max_column} {order_by}"));
+        let (first_column, last_column) = if use_v2_metadata {
+            (
+                quote_ident(&format!("_ts_meta_v2_first_{orderby_column}")),
+                quote_ident(&format!("_ts_meta_v2_last_{orderby_column}")),
+            )
+        } else {
+            (
+                quote_ident(&format!("_ts_meta_min_{column_index}")),
+                quote_ident(&format!("_ts_meta_max_{column_index}")),
+            )
+        };
+        index_columns.push(format!("{first_column} {order_by}"));
+        index_columns.push(format!("{last_column} {order_by}"));
     }
 
     let quoted_index_columns_list: String = index_columns
@@ -868,6 +916,28 @@ async fn create_compressed_chunk_index(
         .await
         .with_context(|| "failed to create compress chunk index")?;
     Ok(())
+}
+
+/// Detects whether a compressed chunk data table uses the v2 sparse-index
+/// metadata columns (`_ts_meta_v2_first_<col>` / `_ts_meta_v2_last_<col>`).
+async fn compressed_chunk_uses_v2_metadata(
+    tx: &Transaction<'_>,
+    qualified_data_table_name: &str,
+) -> Result<bool> {
+    let row = tx
+        .query_one(
+            r"
+            SELECT EXISTS (
+                SELECT 1
+                FROM pg_attribute
+                WHERE attrelid = $1::text::regclass
+                  AND attname ~ '^_ts_meta_v2_first_'
+                  AND NOT attisdropped
+            )",
+            &[&qualified_data_table_name],
+        )
+        .await?;
+    Ok(row.get(0))
 }
 
 async fn fetch_compressed_chunk_compression_settings(
@@ -918,11 +988,21 @@ struct CompressionSettings {
 
 impl From<Row> for CompressionSettings {
     fn from(row: Row) -> Self {
+        // In the relid catalog (TS >= 2.29) the hypertable-level
+        // `compression_settings` row only stores explicitly-configured values,
+        // leaving defaulted columns (e.g. the default time `orderby`) NULL. The
+        // per-chunk rows still materialize them. Treat NULL as empty.
+        fn col(row: &Row, name: &str) -> Vec<String> {
+            row.get::<_, Option<Vec<String>>>(name).unwrap_or_default()
+        }
+        fn flags(row: &Row, name: &str) -> Vec<bool> {
+            row.get::<_, Option<Vec<bool>>>(name).unwrap_or_default()
+        }
         CompressionSettings {
-            segmentby: row.get("segmentby"),
-            orderby: row.get("orderby"),
-            orderby_desc: row.get("orderby_desc"),
-            orderby_nullsfirst: row.get("orderby_nullsfirst"),
+            segmentby: col(&row, "segmentby"),
+            orderby: col(&row, "orderby"),
+            orderby_desc: flags(&row, "orderby_desc"),
+            orderby_nullsfirst: flags(&row, "orderby_nullsfirst"),
         }
     }
 }
@@ -951,7 +1031,22 @@ async fn validate_and_fetch_compression_settings(
     );
     let source_settings =
         fetch_compressed_chunk_compression_settings(source_tx, source_chunk_name).await?;
-    if source_settings != target_settings {
+
+    // In the relid catalog (TS >= 2.29) the hypertable-level settings omit a
+    // defaulted `orderby`, while the source chunk carries the materialized
+    // settings. Consider them compatible when the segment-by columns match and
+    // the target either shares the same explicit `orderby` or relies on the
+    // default (empty), which matches the source chunk's materialized default.
+    let compatible = if features::chunk_catalog_uses_relid() {
+        source_settings.segmentby == target_settings.segmentby
+            && (target_settings.orderby.is_empty()
+                || (source_settings.orderby == target_settings.orderby
+                    && source_settings.orderby_desc == target_settings.orderby_desc
+                    && source_settings.orderby_nullsfirst == target_settings.orderby_nullsfirst))
+    } else {
+        source_settings == target_settings
+    };
+    if !compatible {
         bail!(
             r"Compression settings mismatch.
 
@@ -970,7 +1065,15 @@ backfilled, you can change the settings back and restart the compression jobs.
         );
     }
 
-    Ok(target_settings)
+    // The compressed chunk data table (and its index) must reflect the
+    // materialized layout of the actual compressed data. Pre-2.29 the hypertable
+    // settings already were materialized; in the relid catalog we must use the
+    // source chunk's settings so a defaulted `orderby` is not lost.
+    if features::chunk_catalog_uses_relid() {
+        Ok(source_settings)
+    } else {
+        Ok(target_settings)
+    }
 }
 
 /// Adds the backfill prefix `COMPRESS_TABLE_NAME_PREFIX` to the table name.
@@ -1096,9 +1199,17 @@ async fn fetch_compression_size(
     tx: &Transaction<'_>,
     compressed_chunk: &SourceCompressedChunk,
 ) -> Result<CompressionSize> {
-    let row = tx
-        .query_one(
-            r#"
+    // The numrows_{pre,post}_compression columns were introduced in TimescaleDB
+    // 2.0. The upgrade path does not populate default values for older
+    // installations. Ensure 0 is returned instead of NULL to avoid handling
+    // Option<> in the struct.
+    //
+    // In the relid catalog (TS >= 2.29) `compression_chunk_size` is keyed by the
+    // uncompressed chunk's `chunk_id` (the `compressed_chunk_id` column is dead),
+    // so we reach it from the compressed relation through
+    // `compression_settings.compress_relid`.
+    let query = if features::chunk_catalog_uses_relid() {
+        r#"
 SELECT
     uncompressed_heap_size,
     uncompressed_toast_size,
@@ -1106,19 +1217,31 @@ SELECT
     compressed_heap_size,
     compressed_toast_size,
     compressed_index_size,
-    -- The numrows_{pre,post}_compression columns were introduced
-    -- in TimescaleDB 2.0. The upgrade path does not populate default
-    -- values for older installations.
-    -- Ensure 0 is returned instead of NULL to avoid handling Option<>
-    -- in the struct.
+    COALESCE(numrows_pre_compression, 0) AS numrows_pre_compression,
+    COALESCE(numrows_post_compression, 0) AS numrows_post_compression
+FROM _timescaledb_catalog.compression_chunk_size s
+JOIN _timescaledb_catalog.chunk c ON c.id = s.chunk_id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = c.relid
+WHERE cs.compress_relid = to_regclass(format('%I.%I', $1::text, $2::text))
+        "#
+    } else {
+        r#"
+SELECT
+    uncompressed_heap_size,
+    uncompressed_toast_size,
+    uncompressed_index_size,
+    compressed_heap_size,
+    compressed_toast_size,
+    compressed_index_size,
     COALESCE(numrows_pre_compression, 0) AS numrows_pre_compression,
     COALESCE(numrows_post_compression, 0) AS numrows_post_compression
 FROM _timescaledb_catalog.compression_chunk_size s
 JOIN _timescaledb_catalog.chunk c ON c.id = s.compressed_chunk_id
 WHERE c.schema_name = $1 AND c.table_name = $2
-        "#,
-            &[&compressed_chunk.schema, &compressed_chunk.table],
-        )
+        "#
+    };
+    let row = tx
+        .query_one(query, &[&compressed_chunk.schema, &compressed_chunk.table])
         .await?;
 
     Ok(CompressionSize {
@@ -1137,14 +1260,27 @@ pub async fn chunk_exists<T>(client: &T, chunk: &Chunk) -> Result<bool>
 where
     T: GenericClient,
 {
-    let query: &str = r#"
+    // In the relid catalog (TS >= 2.29) the relation is matched by `relid`;
+    // `to_regclass` yields NULL for a non-existent relation, so the comparison
+    // is simply never true.
+    let query: &str = if features::chunk_catalog_uses_relid() {
+        r#"
+SELECT EXISTS (
+  SELECT 1
+  FROM _timescaledb_catalog.chunk
+  WHERE relid = to_regclass(format('%I.%I', $1::text, $2::text))
+)
+"#
+    } else {
+        r#"
 SELECT EXISTS (
   SELECT 1
   FROM _timescaledb_catalog.chunk
   WHERE schema_name = $1
     AND table_name = $2
 )
-"#;
+"#
+    };
     let exists = client
         .query_one(query, &[&chunk.schema, &chunk.table])
         .await?;

--- a/src/features.rs
+++ b/src/features.rs
@@ -12,11 +12,20 @@ static NO_SEQUENCE_NUMBER_IN_COMPRESSED_HYPERTABLES: OnceLock<bool> = OnceLock::
 static COMPRESSION_SETTINGS_WITH_COMPRESS_RELID: OnceLock<bool> = OnceLock::new();
 static HYPERCORE_TAM: OnceLock<bool> = OnceLock::new();
 static CAGG_INVALIDATION_TRIGGER: OnceLock<bool> = OnceLock::new();
+static CHUNK_CATALOG_USES_RELID: OnceLock<bool> = OnceLock::new();
 
 pub async fn initialize_features(target: &Target) -> Result<()> {
-    let ts_version = &Version::parse(&fetch_tsdb_version(&target.client).await?)?;
+    let mut ts_version = Version::parse(&fetch_tsdb_version(&target.client).await?)?;
+    // Nightly builds report a prerelease version (e.g. `2.29.0-dev`). By semver
+    // rules a prerelease only satisfies a comparator that itself carries a
+    // prerelease with the same major.minor.patch, so a plain `>=X.Y.Z` would
+    // match none of the checks below. Drop the prerelease so a nightly is
+    // treated as its target release for feature gating.
+    ts_version.pre = semver::Prerelease::EMPTY;
+    let ts_version = &ts_version;
     let pg_version = fetch_pg_version_number(&target.client).await?;
 
+    let ts_ge_229 = VersionReq::parse(">=2.29.0").unwrap().matches(ts_version);
     let ts_lt_223 = VersionReq::parse("<2.23.0").unwrap().matches(ts_version);
     let ts_lt_222 = VersionReq::parse("<2.22.0").unwrap().matches(ts_version);
     let ts_ge_219 = VersionReq::parse(">=2.19.0").unwrap().matches(ts_version);
@@ -64,6 +73,10 @@ pub async fn initialize_features(target: &Target) -> Result<()> {
     CAGG_INVALIDATION_TRIGGER
         .set(ts_lt_223)
         .map_err(|e| anyhow!("CAGG_INVALIDATION_TRIGGER already set to {}", e))?;
+
+    CHUNK_CATALOG_USES_RELID
+        .set(ts_ge_229)
+        .map_err(|e| anyhow!("CHUNK_CATALOG_USES_RELID already set to {}", e))?;
     Ok(())
 }
 
@@ -112,4 +125,15 @@ pub fn cagg_invalidation_trigger() -> bool {
     *CAGG_INVALIDATION_TRIGGER
         .get()
         .expect("CAGG_INVALIDATION_TRIGGER is not set")
+}
+
+// Starting with TS 2.29 the `_timescaledb_catalog.chunk` table stores the
+// chunk's relation as a `relid` (regclass) instead of the `schema_name` /
+// `table_name` pair and no longer tracks `compressed_chunk_id`. The compressed
+// relation for a chunk is found through `compression_settings.compress_relid`
+// and its size through `compression_chunk_size.chunk_id`.
+pub fn chunk_catalog_uses_relid() -> bool {
+    *CHUNK_CATALOG_USES_RELID
+        .get()
+        .expect("CHUNK_CATALOG_USES_RELID is not set")
 }

--- a/src/find_source_chunks.sql
+++ b/src/find_source_chunks.sql
@@ -96,8 +96,8 @@ with recursive f as
     from down
 )
 select
-  c.schema_name as chunk_schema
-, c.table_name as chunk_name
+  @chunk_schema@ as chunk_schema
+, @chunk_name@ as chunk_name
 , h.schema_name as hypertable_schema
 , h.table_name as hypertable_name
 , (
@@ -185,5 +185,6 @@ inner join _timescaledb_catalog.dimension_slice ds
 on (d.id = ds.dimension_id and ds.range_start < d.upper_value and (d.lower_value is null or d.lower_value < ds.range_end))
 inner join _timescaledb_catalog.chunk_constraint cc on (ds.id = cc.dimension_slice_id)
 inner join _timescaledb_catalog.chunk c on (cc.chunk_id = c.id and h.id = c.hypertable_id)
+@chunk_relid_join@
 order by ds.range_start desc
 ;

--- a/src/find_target_chunk.sql
+++ b/src/find_target_chunk.sql
@@ -6,8 +6,8 @@ select
 from
 (
     select
-      c.schema_name as chunk_schema
-    , c.table_name as chunk_name
+      @chunk_schema@ as chunk_schema
+    , @chunk_name@ as chunk_name
     , h.schema_name as hypertable_schema
     , h.table_name as hypertable_name
     , count(distinct ds.id) as nbr_dimension_slices
@@ -18,6 +18,7 @@ from
     inner join _timescaledb_catalog.dimension_slice ds on (d.id = ds.dimension_id and ds.range_start = i.range_start and ds.range_end = i.range_end)
     inner join _timescaledb_catalog.chunk_constraint cc on (ds.id = cc.dimension_slice_id)
     inner join _timescaledb_catalog.chunk c on (cc.chunk_id = c.id)
+    @chunk_relid_join@
     where h.schema_name = $1
     and h.table_name = $2
     group by 1, 2, 3, 4

--- a/src/task.rs
+++ b/src/task.rs
@@ -5,7 +5,8 @@ use crate::execute::{
 use crate::sql::assert_regex;
 use crate::storage::{backfill_schema_exists, init_schema};
 use crate::timescale::{
-    set_query_source_proc_schema, Hypertable, QuotedName, SourceChunk, TargetChunk,
+    set_query_chunk_catalog, set_query_source_proc_schema, Hypertable, QuotedName, SourceChunk,
+    TargetChunk,
 };
 use crate::{features, TERM};
 use anyhow::{bail, Result};
@@ -97,10 +98,11 @@ pub async fn find_target_chunk_with_same_dimensions(
     source_chunk: &SourceChunk,
 ) -> Result<TargetChunk> {
     static FIND_TARGET_CHUNK: &str = include_str!("find_target_chunk.sql");
+    let find_target_chunk = set_query_chunk_catalog(FIND_TARGET_CHUNK);
 
     let row = target_tx
         .query_opt(
-            FIND_TARGET_CHUNK,
+            &find_target_chunk,
             &[
                 &source_chunk.hypertable.schema,
                 &source_chunk.hypertable.table,
@@ -206,7 +208,7 @@ pub async fn load_queue(
 
     let target_tx = target.client.transaction().await?;
     static FIND_SOURCE_CHUNKS: &str = include_str!("find_source_chunks.sql");
-    let query = set_query_source_proc_schema(FIND_SOURCE_CHUNKS);
+    let query = set_query_chunk_catalog(&set_query_source_proc_schema(FIND_SOURCE_CHUNKS));
     let source_tx = source.transaction().await?;
 
     let rows = match source_tx

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -67,6 +67,37 @@ pub fn set_query_target_proc_schema(query: &str) -> String {
     query.replace(EXTSCHEMA, schema)
 }
 
+/// Lateral join that resolves a chunk's `relid` to its `schema`/`table` for the
+/// relid catalog (TS >= 2.29). It assumes the chunk table is aliased `c`.
+const CHUNK_RELID_JOIN: &str = "
+inner join lateral (
+    select nc.nspname, clc.relname
+    from pg_class clc
+    join pg_namespace nc on nc.oid = clc.relnamespace
+    where clc.oid = c.relid
+) chunk_rel on true";
+
+/// Fills in the chunk-catalog placeholders in a query so it targets either the
+/// pre-relid catalog (`schema_name`/`table_name`) or the relid catalog
+/// (TS >= 2.29, where the chunk relation is resolved from `relid`). The chunk
+/// table must be aliased `c`.
+///
+/// Placeholders:
+/// - `@chunk_schema@` / `@chunk_name@`: the chunk's schema/table expressions
+/// - `@chunk_relid_join@`: join that exposes them in the relid catalog
+pub fn set_query_chunk_catalog(query: &str) -> String {
+    let (chunk_schema, chunk_name, chunk_relid_join) =
+        if crate::features::chunk_catalog_uses_relid() {
+            ("chunk_rel.nspname", "chunk_rel.relname", CHUNK_RELID_JOIN)
+        } else {
+            ("c.schema_name", "c.table_name", "")
+        };
+    query
+        .replace("@chunk_schema@", chunk_schema)
+        .replace("@chunk_name@", chunk_name)
+        .replace("@chunk_relid_join@", chunk_relid_join)
+}
+
 pub async fn fetch_tsdb_version<T: GenericClient>(client: &T) -> Result<String> {
     let tsdb_version = client
         .query_one(

--- a/tests/cloud_init.sql
+++ b/tests/cloud_init.sql
@@ -253,13 +253,15 @@ DO $$
 
     -- The telemetry events table is intended for application data (like cli tools)
     -- that should be included in telemetry.
-    IF EXISTS (
-      SELECT FROM pg_tables
-      WHERE schemaname = '_timescaledb_catalog'
-        AND tablename = 'telemetry_event'
-    ) THEN
-      GRANT INSERT ON TABLE _timescaledb_catalog.telemetry_event TO tsdbadmin;
-    END IF;
+    -- TimescaleDB removed this catalog table from core after 2.26; Tiger Cloud
+    -- still provisions it (backfill writes telemetry to it), so recreate it here
+    -- to simulate the cloud environment.
+    CREATE TABLE IF NOT EXISTS _timescaledb_catalog.telemetry_event (
+        created timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        tag name NOT NULL,
+        body jsonb NOT NULL
+    );
+    GRANT INSERT ON TABLE _timescaledb_catalog.telemetry_event TO tsdbadmin;
 
     -- We should allow the creation of new chunk tables within the _timescaledb_internal schema using pg_restore.
     -- Although we could implement an event trigger to specifically filter chunk tables, this may be unnecessary since

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1429,7 +1429,6 @@ fn copy_without_stage_error() -> Result<()> {
 
     let source_container = docker.run(timescaledb(pg_version(), ts_version()));
     let target_container = docker.run(timescaledb(pg_version(), ts_version()));
-    provision_telemetry_event(&target_container)?;
 
     run_backfill(
         TestConfigCopy::new(&source_container, &target_container),
@@ -1452,6 +1451,7 @@ fn copy_without_available_tasks_error() -> Result<()> {
 
     let source_container = docker.run(timescaledb(pg_version(), ts_version()));
     let target_container = docker.run(timescaledb(pg_version(), ts_version()));
+    provision_telemetry_event(&target_container)?;
 
     run_backfill(TestConfigStage::new(
         &source_container,
@@ -2917,18 +2917,38 @@ fn panic_on_copy_if_source_has_compressed_chunk_not_present_in_target_with_diffe
     // the new compressed chunk during staging, but the compression settings for the
     // hypertable in target are different than the chunk's compression settings
     // in the source.
-    result.stderr(
-        contains(
-            "Compression settings mismatch."
-        ).and(contains(
-            "Compression settings for the compressed chunk '_timescaledb_internal.compress_hyper_2_7_chunk'"
-        )).and(contains(
-            "in source are different than the settings for the hypertable 'public.metrics'"
-        )).and(contains(
-            r#"- SOURCE: CompressionSettings { segmentby: ["device_id", "label"], orderby: ["time"], orderby_desc: [false], orderby_nullsfirst: [false] }"#
-        )).and(contains(
-            r#"- TARGET: CompressionSettings { segmentby: ["device_id"], orderby: ["time"], orderby_desc: [false], orderby_nullsfirst: [false] }"#
+    //
+    let settings = contains("Compression settings mismatch.")
+        .and(contains(
+            "in source are different than the settings for the hypertable 'public.metrics'",
+        ))
+        .and(contains(
+            r#"- SOURCE: CompressionSettings { segmentby: ["device_id", "label"], orderby: ["time"], orderby_desc: [false], orderby_nullsfirst: [false] }"#,
+        ))
+        .and(contains(
+            r#"- TARGET: CompressionSettings { segmentby: ["device_id"], orderby: ["time"], orderby_desc: [false], orderby_nullsfirst: [false] }"#,
+        ));
+
+    // TS >= 2.29 (relid catalog) names compressed chunks
+    // `_hyper_<ht>_<id>_chunk_compressed` (by an id we can't predict here)
+    // instead of `compress_hyper_<ht>_<id>_chunk`; the settings themselves are
+    // reported identically.
+    let mut ts = Version::parse(&get_ts_version(&source_container.connection_string())?)?;
+    ts.pre = semver::Prerelease::EMPTY;
+    let relid_catalog = VersionReq::parse(">=2.29.0").unwrap().matches(&ts);
+    if relid_catalog {
+        result.stderr(
+            settings
+                .and(contains(
+                    "Compression settings for the compressed chunk '_timescaledb_internal.",
+                ))
+                .and(contains("_chunk_compressed'")),
+        );
+    } else {
+        result.stderr(settings.and(contains(
+            "Compression settings for the compressed chunk '_timescaledb_internal.compress_hyper_2_7_chunk'",
         )));
+    }
 
     Ok(())
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -371,6 +371,25 @@ fn configure_cloud_setup<C: HasConnectionString>(container: &C) -> Result<()> {
     Ok(())
 }
 
+/// Tiger Cloud provisions `_timescaledb_catalog.telemetry_event`, which
+/// TimescaleDB removed from core after 2.26. Backfill writes telemetry to this
+/// table (on the target) only when it exists, so tests that assert telemetry
+/// must provision it to exercise the feature on newer versions. On older
+/// versions the table already exists and `IF NOT EXISTS` makes this a no-op.
+fn provision_telemetry_event<C: HasConnectionString>(container: &C) -> Result<()> {
+    psql(
+        &container,
+        PsqlInput::Sql(
+            "CREATE TABLE IF NOT EXISTS _timescaledb_catalog.telemetry_event (
+                created timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                tag name NOT NULL,
+                body jsonb NOT NULL
+            )",
+        ),
+    )?;
+    Ok(())
+}
+
 generate_tests!(
     (
         copy_data_from_chunks,
@@ -1410,6 +1429,7 @@ fn copy_without_stage_error() -> Result<()> {
 
     let source_container = docker.run(timescaledb(pg_version(), ts_version()));
     let target_container = docker.run(timescaledb(pg_version(), ts_version()));
+    provision_telemetry_event(&target_container)?;
 
     run_backfill(
         TestConfigCopy::new(&source_container, &target_container),
@@ -2010,6 +2030,7 @@ fn verify_task_with_extra_rows_in_source() -> Result<()> {
 
     let source_container = docker.run(timescaledb(pg_version(), ts_version()));
     let target_container = docker.run(timescaledb(pg_version(), ts_version()));
+    provision_telemetry_event(&target_container)?;
 
     // Given a chunk that's staged and copied
     stage_and_copy_a_single_chunk(&source_container, &target_container)?;
@@ -2229,6 +2250,7 @@ where
         PsqlInput::File(PathBuf::from("tests/source_schema.sql")),
     )?;
     copy_skeleton_schema(&source_container, &target_container)?;
+    provision_telemetry_event(&target_container)?;
 
     let mut source_dbassert = DbAssert::new(&source_container.connection_string())
         .unwrap()
@@ -2527,6 +2549,7 @@ fn telemetry_captures_error_reason() -> Result<()> {
     psql(&source_container, PsqlInput::Sql(INSERT_DATA_FOR_MAY))?;
 
     copy_skeleton_schema(&source_container, &target_container)?;
+    provision_telemetry_event(&target_container)?;
 
     psql(&target_container, PsqlInput::Sql("drop table metrics"))?;
     psql(


### PR DESCRIPTION
## Why

TimescaleDB 2.29 (currently only a nightly build) reworks `_timescaledb_catalog.chunk`, which this tool queries directly. Building on #193 (which handled the 2.23–2.26 changes: `dropped` removal and the cagg invalidation trigger), this extends support to 2.27, 2.28 and the 2.29 nightly line.

## What

**2.29 chunk catalog.** The chunk relation is now a `relid` (regclass) instead of `schema_name`/`table_name`; `compressed_chunk_id` is gone; the compressed relation is reached via `compression_settings.compress_relid` and its size via `compression_chunk_size.chunk_id`. The affected catalog queries are version-gated behind a new `chunk_catalog_uses_relid()` feature (`>= 2.29.0`), using placeholder substitution for the two `find_*_chunk.sql` files.

Also fixes issues that only surface on 2.27–2.29:
- **Prerelease semver** — a nightly reports `2.29.0-dev`, which a plain `>=X.Y.Z` comparator never matches, silently disabling every feature flag. The prerelease is stripped before gating.
- **NULL/sparse compression settings** — 2.29 leaves a defaulted `orderby` NULL at the hypertable level; tolerate NULL and build/validate compressed chunks from the materialized chunk-level settings.
- **v2 sparse index** — the compressed index metadata moved to `_ts_meta_v2_first_<col>`/`_ts_meta_v2_last_<col>`; the index is built from whichever columns the data table actually has (also fixes the DDL-parity test on 2.28).

**Tests / CI.** `telemetry_event` was removed from the core catalog after 2.26 but Tiger Cloud still provisions it (backfill writes telemetry to it), so it's provisioned in the cloud simulation and in the telemetry-asserting tests. The CI matrix becomes the latest release of each Cloud minor (2.22–2.28) plus nightly; nightly is non-blocking.

**test-common** stays a separate library: pinned to the branch adding `TS227`/`TS228`/`Nightly` + the nightly image (timescale/test-common#43).

## Validation

- Manual `stage`/`copy`/`verify` between two nightly (2.29) instances with compression + continuous aggregates: **data matches exactly** (rows, checksum, cagg rows, compressed chunks recreated and queryable).
- 2.28: compressed-chunk DDL parity, `copy_continuous_aggregates`, and telemetry tests pass.
- Unit tests, fmt, clippy green.

## Notes

- The nightly image is amd64-only; runs natively on CI (amd64), needs `--platform linux/amd64` locally on Apple Silicon.
- Supersedes the earlier vendoring-based draft (#196), now closed.
