### PR TITLE
feat: fall back to uncompressed copy on unbacked sparse-index metadata

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1065,6 +1065,14 @@ backfilled, you can change the settings back and restart the compression jobs.
         );
     }
 
+    validate_sparse_index_metadata(
+        source_tx,
+        target_tx,
+        source_chunk_name,
+        target_hypertable_name,
+    )
+    .await?;
+
     // The compressed chunk data table (and its index) must reflect the
     // materialized layout of the actual compressed data. Pre-2.29 the hypertable
     // settings already were materialized; in the relid catalog we must use the
@@ -1074,6 +1082,142 @@ backfilled, you can change the settings back and restart the compression jobs.
     } else {
         Ok(target_settings)
     }
+}
+
+/// A sparse-index metadata entry from `compression_settings.index`, identified
+/// by its type (e.g. `minmax`, `firstlast`) and the column it indexes.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SparseIndexEntry {
+    kind: String,
+    column: String,
+}
+
+impl std::fmt::Display for SparseIndexEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} on {}", self.kind, self.column)
+    }
+}
+
+/// Parses the `index` jsonb column of `compression_settings` into a list of
+/// sparse-index entries. A NULL/absent value or unexpected shape yields an
+/// empty list.
+fn parse_sparse_index(value: Option<serde_json::Value>) -> Vec<SparseIndexEntry> {
+    let Some(serde_json::Value::Array(entries)) = value else {
+        return vec![];
+    };
+    entries
+        .iter()
+        .filter_map(|entry| {
+            Some(SparseIndexEntry {
+                kind: entry.get("type")?.as_str()?.to_string(),
+                column: entry.get("column")?.as_str()?.to_string(),
+            })
+        })
+        .collect()
+}
+
+/// Returns the sparse-index entries declared by the target hypertable that the
+/// source chunk cannot back.
+///
+/// `minmax` always has a working representation (positional `_ts_meta_min_N` or
+/// the v2 `_ts_meta_v2_min_<col>` columns), so it never dangles and is ignored.
+/// Any other entry the target declares but the source lacks would be stamped
+/// onto the target chunk without backing columns.
+fn unbacked_sparse_index_entries<'a>(
+    target_index: &'a [SparseIndexEntry],
+    source_index: &[SparseIndexEntry],
+) -> Vec<&'a SparseIndexEntry> {
+    let source_entries: std::collections::HashSet<&SparseIndexEntry> =
+        source_index.iter().collect();
+    target_index
+        .iter()
+        .filter(|entry| entry.kind != "minmax")
+        .filter(|entry| !source_entries.contains(entry))
+        .collect()
+}
+
+/// Fetches the sparse-index metadata (`compression_settings.index`) for the
+/// relation matching `relid_column = $1`.
+async fn fetch_sparse_index(
+    tx: &Transaction<'_>,
+    relid_column: &str,
+    table_name: &String,
+) -> Result<Vec<SparseIndexEntry>> {
+    let query = format!(
+        r"
+        SELECT index
+        FROM _timescaledb_catalog.compression_settings
+        WHERE {relid_column} = $1::text::regclass
+    "
+    );
+    let index: Option<serde_json::Value> = tx.query_one(&query, &[&table_name]).await?.get("index");
+    Ok(parse_sparse_index(index))
+}
+
+/// Guards against the sparse-index metadata mismatch described in issue #195.
+///
+/// From TS 2.28 the hypertable-level `compression_settings.index` carries
+/// entries such as `firstlast` that `create_compressed_chunk` copies verbatim
+/// onto every new chunk. When a source chunk was compressed under an older
+/// format its physical table lacks the `_ts_meta_*` columns backing those
+/// entries (the target chunk data table is a copy of that layout), so the
+/// copied metadata references columns that do not exist. On PG16 targets this
+/// makes every query that plans over the chunk fail with a `cache lookup
+/// failed for attribute 0` error; on PG17 the planner silently tolerates it.
+async fn validate_sparse_index_metadata(
+    source_tx: &Transaction<'_>,
+    target_tx: &Transaction<'_>,
+    source_chunk_name: &str,
+    target_hypertable_name: &str,
+) -> Result<()> {
+    if !features::hypertable_sparse_index_metadata() {
+        return Ok(());
+    }
+
+    let target_index =
+        fetch_sparse_index(target_tx, "relid", &target_hypertable_name.to_string()).await?;
+    let source_relid_column = if features::compression_settings_with_compress_relid() {
+        "compress_relid"
+    } else {
+        "relid"
+    };
+    let source_index = fetch_sparse_index(
+        source_tx,
+        source_relid_column,
+        &source_chunk_name.to_string(),
+    )
+    .await?;
+
+    let unbacked: Vec<String> = unbacked_sparse_index_entries(&target_index, &source_index)
+        .into_iter()
+        .map(|entry| entry.to_string())
+        .collect();
+
+    if !unbacked.is_empty() {
+        bail!(
+            r"Sparse-index metadata mismatch (see https://github.com/timescale/timescaledb-backfill/issues/195).
+
+The compressed chunk '{source_chunk_name}' in the source was compressed under an
+older format and lacks the physical columns backing these sparse-index entries
+declared by the target hypertable '{target_hypertable_name}':
+
+- {}
+
+Backfilling it would copy those entries onto the target chunk without their
+backing columns, corrupting its catalog metadata. On PG16 targets this makes
+every query over the chunk fail with 'cache lookup failed for attribute 0'.
+
+Rebuild the affected source chunk(s) so their physical layout matches the
+current compression format, then restart the copy:
+
+    SELECT decompress_chunk(c), compress_chunk(c)
+    FROM show_chunks('<hypertable>') c;
+",
+            unbacked.join("\n- ")
+        );
+    }
+
+    Ok(())
 }
 
 /// Adds the backfill prefix `COMPRESS_TABLE_NAME_PREFIX` to the table name.
@@ -1576,4 +1720,99 @@ async fn clone_constraints_to_chunk(
         )
         .await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn entry(kind: &str, column: &str) -> SparseIndexEntry {
+        SparseIndexEntry {
+            kind: kind.to_string(),
+            column: column.to_string(),
+        }
+    }
+
+    #[test]
+    fn parse_sparse_index_reads_type_and_column() {
+        let value = json!([
+            {"type": "minmax", "column": "time"},
+            {"type": "firstlast", "column": "value"},
+        ]);
+        assert_eq!(
+            parse_sparse_index(Some(value)),
+            vec![entry("minmax", "time"), entry("firstlast", "value")],
+        );
+    }
+
+    #[test]
+    fn parse_sparse_index_null_yields_empty() {
+        assert_eq!(parse_sparse_index(None), vec![]);
+        assert_eq!(parse_sparse_index(Some(serde_json::Value::Null)), vec![]);
+    }
+
+    #[test]
+    fn parse_sparse_index_skips_malformed_entries() {
+        let value = json!([
+            {"type": "firstlast", "column": "value"},
+            {"type": "firstlast"},
+            {"column": "orphan"},
+            {"type": 42, "column": "value"},
+            "not-an-object",
+        ]);
+        assert_eq!(
+            parse_sparse_index(Some(value)),
+            vec![entry("firstlast", "value")],
+        );
+    }
+
+    #[test]
+    fn parse_sparse_index_non_array_yields_empty() {
+        assert_eq!(
+            parse_sparse_index(Some(json!({"type": "firstlast"}))),
+            vec![]
+        );
+    }
+
+    #[test]
+    fn unbacked_flags_firstlast_missing_in_source() {
+        let target = vec![entry("minmax", "time"), entry("firstlast", "value")];
+        let source = vec![entry("minmax", "time")];
+        assert_eq!(
+            unbacked_sparse_index_entries(&target, &source),
+            vec![&entry("firstlast", "value")],
+        );
+    }
+
+    #[test]
+    fn unbacked_ignores_minmax() {
+        let target = vec![entry("minmax", "time"), entry("minmax", "value")];
+        let source = vec![];
+        assert!(unbacked_sparse_index_entries(&target, &source).is_empty());
+    }
+
+    #[test]
+    fn unbacked_empty_when_source_backs_all_entries() {
+        let target = vec![entry("minmax", "time"), entry("firstlast", "value")];
+        let source = vec![entry("firstlast", "value")];
+        assert!(unbacked_sparse_index_entries(&target, &source).is_empty());
+    }
+
+    #[test]
+    fn unbacked_empty_when_source_is_superset() {
+        let target = vec![entry("firstlast", "value")];
+        let source = vec![entry("firstlast", "value"), entry("firstlast", "other")];
+        assert!(unbacked_sparse_index_entries(&target, &source).is_empty());
+    }
+
+    #[test]
+    fn unbacked_matches_on_column_not_just_kind() {
+        let target = vec![entry("firstlast", "value")];
+        let source = vec![entry("firstlast", "other")];
+        assert_eq!(
+            unbacked_sparse_index_entries(&target, &source),
+            vec![&entry("firstlast", "value")],
+        );
+    }
 }

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -35,6 +35,40 @@ pub async fn copy_chunk(
         find_target_chunk_with_same_dimensions(target_tx, &task.source_chunk).await?;
 
     let source_chunk_compressed = is_chunk_compressed(source_tx, &task.source_chunk).await?;
+    let source_compressed_chunk = get_compressed_chunk(source_tx, &task.source_chunk).await?;
+
+    // A source chunk compressed under an older format can't be copied in
+    // compressed form: its physical layout doesn't back the sparse-index
+    // metadata the target hypertable declares (issue #195). Copy its rows in
+    // uncompressed form instead and let the target compress them in its own
+    // format.
+    //
+    // This must be decided before the completion-filter branch below, which
+    // recompresses the target chunk only when it was already compressed:
+    // `stage` deliberately leaves the affected chunks uncompressed, so taking
+    // that branch would leave the chunk holding the `--until` boundary
+    // uncompressed forever. Detection is re-run here instead of read from the
+    // task, so a `stage` warning has not necessarily preceded it: tasks staged
+    // by a binary without this check reach the fallback too.
+    if let Some(source_compressed_chunk) = &source_compressed_chunk {
+        let target_hypertable_index =
+            fetch_hypertable_sparse_index(target_tx, &target_chunk.hypertable).await?;
+        let unbacked = unbacked_sparse_index_metadata(
+            source_tx,
+            source_compressed_chunk,
+            &target_hypertable_index,
+        )
+        .await?;
+        if !unbacked.is_empty() {
+            warn!(
+                "chunk {} was compressed under an older format which cannot back the sparse-index metadata of hypertable {} ({}), copying its rows uncompressed and recompressing in target",
+                task.source_chunk.quoted_name(),
+                target_chunk.hypertable.quoted_name(),
+                unbacked.join(", "),
+            );
+            return copy_chunk_data_and_recompress(source_tx, target_tx, task, &target_chunk).await;
+        }
+    }
 
     // If we're trying to filter on a compressed chunk, fall back to reading rows directly
     // from the uncompressed chunk, and write the uncompressed rows into the target.
@@ -75,8 +109,6 @@ pub async fn copy_chunk(
         }
         return Ok(result);
     }
-
-    let source_compressed_chunk = get_compressed_chunk(source_tx, &task.source_chunk).await?;
 
     let target_chunk_is_compressed = is_chunk_compressed(target_tx, &target_chunk).await?;
 
@@ -168,6 +200,47 @@ pub async fn copy_chunk(
         rows: uncompressed_result.rows + compressed_result.as_ref().map(|r| r.rows).unwrap_or(0),
         bytes: uncompressed_result.bytes + compressed_result.as_ref().map(|r| r.bytes).unwrap_or(0),
     })
+}
+
+/// Copies a compressed source chunk's rows in uncompressed form and compresses
+/// the target chunk afterwards, so the target holds data compressed in its own
+/// format instead of a byte-level copy of the source's compressed layout.
+async fn copy_chunk_data_and_recompress(
+    source_tx: &Transaction<'_>,
+    target_tx: &Transaction<'_>,
+    task: &CopyTask,
+    target_chunk: &TargetChunk,
+) -> Result<CopyResult> {
+    // The target chunk must be uncompressed to receive the rows: deleting or
+    // inserting uncompressed rows doesn't reach its compressed chunk.
+    if is_chunk_compressed(target_tx, target_chunk).await? {
+        // On a resumed backfill the target chunk can be compressed only because
+        // an earlier `stage` (from a binary without the check above)
+        // pre-created its compressed chunk carrying the copied, unbacked
+        // metadata. `decompress_chunk` plans over that chunk, which is exactly
+        // what fails with `cache lookup failed for attribute 0` on PG16, so
+        // report what actually happened instead of surfacing the planner error.
+        // PG17 tolerates the planning, so there the decompression succeeds and
+        // the recompression below rebuilds the chunk in a backed layout.
+        let unbacked = unbacked_target_chunk_metadata(target_tx, target_chunk).await?;
+        decompress_chunk(target_tx, target_chunk)
+            .await
+            .with_context(|| decompress_failure_context(target_chunk, &unbacked))?;
+    }
+
+    let result = copy_chunk_data(
+        source_tx,
+        target_tx,
+        &task.source_chunk,
+        target_chunk,
+        &task.filter,
+        CopyMode::UncompressedAndCompressed,
+    )
+    .await?;
+
+    compress_chunk(target_tx, target_chunk).await?;
+
+    Ok(result)
 }
 
 async fn create_compressed_chunk_from_source_chunk(
@@ -1065,14 +1138,6 @@ backfilled, you can change the settings back and restart the compression jobs.
         );
     }
 
-    validate_sparse_index_metadata(
-        source_tx,
-        target_tx,
-        source_chunk_name,
-        target_hypertable_name,
-    )
-    .await?;
-
     // The compressed chunk data table (and its index) must reflect the
     // materialized layout of the actual compressed data. Pre-2.29 the hypertable
     // settings already were materialized; in the relid catalog we must use the
@@ -1087,7 +1152,7 @@ backfilled, you can change the settings back and restart the compression jobs.
 /// A sparse-index metadata entry from `compression_settings.index`, identified
 /// by its type (e.g. `minmax`, `firstlast`) and the column it indexes.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct SparseIndexEntry {
+pub struct SparseIndexEntry {
     kind: String,
     column: String,
 }
@@ -1099,45 +1164,108 @@ impl std::fmt::Display for SparseIndexEntry {
 }
 
 /// Parses the `index` jsonb column of `compression_settings` into a list of
-/// sparse-index entries. A NULL/absent value or unexpected shape yields an
-/// empty list.
-fn parse_sparse_index(value: Option<serde_json::Value>) -> Vec<SparseIndexEntry> {
-    let Some(serde_json::Value::Array(entries)) = value else {
-        return vec![];
+/// sparse-index entries. An absent or NULL value yields an empty list; any
+/// other shape the parser cannot positively interpret is an error.
+///
+/// This fails closed on purpose. The empty list means "declares no sparse
+/// index", which routes a chunk down the compressed-copy path, so silently
+/// answering it for a catalog shape we don't recognize would let through
+/// exactly the corruption the caller exists to prevent, and that corruption is
+/// invisible on PG17 and unrepairable as `tsdbadmin`.
+fn parse_sparse_index(value: Option<serde_json::Value>) -> Result<Vec<SparseIndexEntry>> {
+    let entries = match value {
+        None | Some(serde_json::Value::Null) => return Ok(vec![]),
+        Some(serde_json::Value::Array(entries)) => entries,
+        Some(other) => bail!("unrecognized compression_settings.index shape: {other}"),
     };
     entries
         .iter()
-        .filter_map(|entry| {
-            Some(SparseIndexEntry {
-                kind: entry.get("type")?.as_str()?.to_string(),
-                column: entry.get("column")?.as_str()?.to_string(),
+        .map(|entry| {
+            let field = |name: &str| -> Result<String> {
+                entry
+                    .get(name)
+                    .and_then(|value| value.as_str())
+                    .map(|value| value.to_string())
+                    .with_context(|| {
+                        format!("compression_settings.index entry has no string `{name}`: {entry}")
+                    })
+            };
+            Ok(SparseIndexEntry {
+                kind: field("type")?,
+                column: field("column")?,
             })
         })
         .collect()
 }
 
-/// Returns the sparse-index entries declared by the target hypertable that the
-/// source chunk cannot back.
+/// The physical columns of a compressed chunk that back a sparse-index entry,
+/// or `None` for an entry type whose physical layout we don't know.
 ///
-/// `minmax` always has a working representation (positional `_ts_meta_min_N` or
-/// the v2 `_ts_meta_v2_min_<col>` columns), so it never dangles and is ignored.
-/// Any other entry the target declares but the source lacks would be stamped
-/// onto the target chunk without backing columns.
-fn unbacked_sparse_index_entries<'a>(
-    target_index: &'a [SparseIndexEntry],
-    source_index: &[SparseIndexEntry],
+/// `firstlast` is materialized as `_ts_meta_v2_first_<column>` /
+/// `_ts_meta_v2_last_<column>`, the same columns `create_compressed_chunk_index`
+/// builds its index on.
+fn sparse_index_backing_columns(entry: &SparseIndexEntry) -> Option<Vec<String>> {
+    match entry.kind.as_str() {
+        "firstlast" => Some(vec![
+            format!("_ts_meta_v2_first_{}", entry.column),
+            format!("_ts_meta_v2_last_{}", entry.column),
+        ]),
+        _ => None,
+    }
+}
+
+/// Filters `entries` down to those the compressed chunk's `columns` cannot back.
+///
+/// `minmax` is skipped: it always has a working representation on a compressed
+/// chunk, either the positional `_ts_meta_min_N` columns or the v2
+/// `_ts_meta_v2_min_<col>` ones, so it never dangles.
+fn unbacked_entries<'a>(
+    entries: &'a [SparseIndexEntry],
+    columns: &std::collections::HashSet<String>,
 ) -> Vec<&'a SparseIndexEntry> {
-    let source_entries: std::collections::HashSet<&SparseIndexEntry> =
-        source_index.iter().collect();
-    target_index
+    entries
         .iter()
         .filter(|entry| entry.kind != "minmax")
-        .filter(|entry| !source_entries.contains(entry))
+        .filter(|entry| match sparse_index_backing_columns(entry) {
+            Some(required) => !required.iter().all(|column| columns.contains(column)),
+            // An entry type whose physical layout we don't know can't be
+            // verified. Call it unbacked: the fallback is only slower, while a
+            // wrong "compatible" answer corrupts the target chunk's catalog.
+            None => true,
+        })
         .collect()
 }
 
+/// The `_ts_meta_*` column names present on a compressed chunk's physical table.
+async fn fetch_metadata_columns(
+    tx: &Transaction<'_>,
+    table_name: &String,
+) -> Result<std::collections::HashSet<String>> {
+    let rows = tx
+        .query(
+            r"
+            SELECT attname
+            FROM pg_attribute
+            WHERE attrelid = $1::text::regclass
+              AND attname ~ '^_ts_meta_'
+              AND attnum > 0
+              AND NOT attisdropped",
+            &[table_name],
+        )
+        .await
+        .with_context(|| format!("failed to read metadata columns of {table_name}"))?;
+    Ok(rows
+        .iter()
+        .map(|row| row.get::<_, String>("attname"))
+        .collect())
+}
+
 /// Fetches the sparse-index metadata (`compression_settings.index`) for the
-/// relation matching `relid_column = $1`.
+/// relation matching `relid_column = $1`. A relation without a compression
+/// settings row is an error: an empty index and a missing row mean different
+/// things to the callers, and the sibling
+/// `fetch_compressed_chunk_compression_settings` treats a missing row the same
+/// way.
 async fn fetch_sparse_index(
     tx: &Transaction<'_>,
     relid_column: &str,
@@ -1150,11 +1278,33 @@ async fn fetch_sparse_index(
         WHERE {relid_column} = $1::text::regclass
     "
     );
-    let index: Option<serde_json::Value> = tx.query_one(&query, &[&table_name]).await?.get("index");
-    Ok(parse_sparse_index(index))
+    let row = tx
+        .query_opt(&query, &[&table_name])
+        .await?
+        .with_context(|| format!("no compression settings found for {table_name}"))?;
+    parse_sparse_index(row.get("index"))
 }
 
-/// Guards against the sparse-index metadata mismatch described in issue #195.
+/// Fetches the sparse-index entries the target hypertable declares, which
+/// `create_compressed_chunk` stamps onto every compressed chunk it creates.
+///
+/// Invariant per hypertable, so `stage` fetches it once per hypertable rather
+/// than once per chunk.
+pub async fn fetch_hypertable_sparse_index(
+    target_tx: &Transaction<'_>,
+    target_hypertable: &Hypertable,
+) -> Result<Vec<SparseIndexEntry>> {
+    if !features::hypertable_sparse_index_metadata() {
+        return Ok(vec![]);
+    }
+    let target_hypertable_name =
+        format!("{}.{}", target_hypertable.schema, target_hypertable.table);
+    fetch_sparse_index(target_tx, "relid", &target_hypertable_name).await
+}
+
+/// Detects the sparse-index metadata mismatch described in issue #195, and
+/// returns the entries of `target_hypertable_index` that the source compressed
+/// chunk's physical layout cannot back (empty when it backs them all).
 ///
 /// From TS 2.28 the hypertable-level `compression_settings.index` carries
 /// entries such as `firstlast` that `create_compressed_chunk` copies verbatim
@@ -1164,60 +1314,87 @@ async fn fetch_sparse_index(
 /// copied metadata references columns that do not exist. On PG16 targets this
 /// makes every query that plans over the chunk fail with a `cache lookup
 /// failed for attribute 0` error; on PG17 the planner silently tolerates it.
-async fn validate_sparse_index_metadata(
+///
+/// The mismatch is catalog-versus-physical, so this reads the source chunk's
+/// actual columns rather than comparing the two catalogs: a chunk's
+/// `compression_settings` row materializes defaults the hypertable row omits,
+/// which makes catalog-to-catalog equality report compatible layouts as
+/// mismatched.
+///
+/// A chunk with unbacked entries cannot be copied in compressed form. `copy`
+/// falls back to copying its rows uncompressed and letting the target compress
+/// them in its own format; `stage` only skips pre-creating the target
+/// compressed chunk and warns, leaving the copy decision to `copy`.
+pub async fn unbacked_sparse_index_metadata(
     source_tx: &Transaction<'_>,
-    target_tx: &Transaction<'_>,
-    source_chunk_name: &str,
-    target_hypertable_name: &str,
-) -> Result<()> {
-    if !features::hypertable_sparse_index_metadata() {
-        return Ok(());
+    source_compressed_chunk: &SourceCompressedChunk,
+    target_hypertable_index: &[SparseIndexEntry],
+) -> Result<Vec<String>> {
+    if target_hypertable_index
+        .iter()
+        .all(|entry| entry.kind == "minmax")
+    {
+        return Ok(vec![]);
     }
 
-    let target_index =
-        fetch_sparse_index(target_tx, "relid", &target_hypertable_name.to_string()).await?;
-    let source_relid_column = if features::compression_settings_with_compress_relid() {
-        "compress_relid"
-    } else {
-        "relid"
-    };
-    let source_index = fetch_sparse_index(
-        source_tx,
-        source_relid_column,
-        &source_chunk_name.to_string(),
-    )
-    .await?;
+    let source_chunk_name = format!(
+        "{}.{}",
+        source_compressed_chunk.schema, source_compressed_chunk.table
+    );
+    let source_columns = fetch_metadata_columns(source_tx, &source_chunk_name).await?;
 
-    let unbacked: Vec<String> = unbacked_sparse_index_entries(&target_index, &source_index)
+    Ok(unbacked_entries(target_hypertable_index, &source_columns)
         .into_iter()
         .map(|entry| entry.to_string())
-        .collect();
+        .collect())
+}
 
-    if !unbacked.is_empty() {
-        bail!(
-            r"Sparse-index metadata mismatch (see https://github.com/timescale/timescaledb-backfill/issues/195).
-
-The compressed chunk '{source_chunk_name}' in the source was compressed under an
-older format and lacks the physical columns backing these sparse-index entries
-declared by the target hypertable '{target_hypertable_name}':
-
-- {}
-
-Backfilling it would copy those entries onto the target chunk without their
-backing columns, corrupting its catalog metadata. On PG16 targets this makes
-every query over the chunk fail with 'cache lookup failed for attribute 0'.
-
-Rebuild the affected source chunk(s) so their physical layout matches the
-current compression format, then restart the copy:
-
-    SELECT decompress_chunk(c), compress_chunk(c)
-    FROM show_chunks('<hypertable>') c;
-",
-            unbacked.join("\n- ")
-        );
+/// Returns the entries in the target chunk's own compressed-chunk metadata that
+/// its physical layout cannot back, i.e. the corruption of issue #195 already
+/// present in the target.
+async fn unbacked_target_chunk_metadata(
+    target_tx: &Transaction<'_>,
+    target_chunk: &TargetChunk,
+) -> Result<Vec<String>> {
+    if !features::hypertable_sparse_index_metadata() {
+        return Ok(vec![]);
     }
+    let Some(target_compressed_chunk) = get_compressed_chunk(target_tx, target_chunk).await? else {
+        return Ok(vec![]);
+    };
+    let target_compressed_chunk_name = format!(
+        "{}.{}",
+        target_compressed_chunk.schema, target_compressed_chunk.table
+    );
+    // Chunk-level settings are keyed by `compress_relid`; reaching this code
+    // requires TS >= 2.28, which implies the column exists.
+    let index =
+        fetch_sparse_index(target_tx, "compress_relid", &target_compressed_chunk_name).await?;
+    let columns = fetch_metadata_columns(target_tx, &target_compressed_chunk_name).await?;
+    Ok(unbacked_entries(&index, &columns)
+        .into_iter()
+        .map(|entry| entry.to_string())
+        .collect())
+}
 
-    Ok(())
+/// The context for a failed decompression of a target chunk, naming the issue
+/// #195 corruption as the cause when the chunk's metadata carries it.
+fn decompress_failure_context(target_chunk: &TargetChunk, unbacked: &[String]) -> String {
+    let chunk = target_chunk.quoted_name();
+    if unbacked.is_empty() {
+        return format!("failed to decompress target chunk {chunk}");
+    }
+    format!(
+        r"failed to decompress target chunk {chunk}.
+
+Its compressed chunk was pre-created by an earlier `stage` with sparse-index
+metadata that its physical layout does not back ({entries}), which PG16 cannot
+plan over (issue #195). Drop the compressed chunk in the target, then run
+`stage` again with this version of timescaledb-backfill, which leaves the
+affected chunks uncompressed until `copy` recompresses them in the target's own
+format.",
+        entries = unbacked.join(", "),
+    )
 }
 
 /// Adds the backfill prefix `COMPRESS_TABLE_NAME_PREFIX` to the table name.
@@ -1734,6 +1911,10 @@ mod tests {
         }
     }
 
+    fn columns(names: &[&str]) -> std::collections::HashSet<String> {
+        names.iter().map(|name| name.to_string()).collect()
+    }
+
     #[test]
     fn parse_sparse_index_reads_type_and_column() {
         let value = json!([
@@ -1741,78 +1922,125 @@ mod tests {
             {"type": "firstlast", "column": "value"},
         ]);
         assert_eq!(
-            parse_sparse_index(Some(value)),
+            parse_sparse_index(Some(value)).unwrap(),
             vec![entry("minmax", "time"), entry("firstlast", "value")],
         );
     }
 
     #[test]
     fn parse_sparse_index_null_yields_empty() {
-        assert_eq!(parse_sparse_index(None), vec![]);
-        assert_eq!(parse_sparse_index(Some(serde_json::Value::Null)), vec![]);
-    }
-
-    #[test]
-    fn parse_sparse_index_skips_malformed_entries() {
-        let value = json!([
-            {"type": "firstlast", "column": "value"},
-            {"type": "firstlast"},
-            {"column": "orphan"},
-            {"type": 42, "column": "value"},
-            "not-an-object",
-        ]);
+        assert_eq!(parse_sparse_index(None).unwrap(), vec![]);
         assert_eq!(
-            parse_sparse_index(Some(value)),
-            vec![entry("firstlast", "value")],
-        );
-    }
-
-    #[test]
-    fn parse_sparse_index_non_array_yields_empty() {
-        assert_eq!(
-            parse_sparse_index(Some(json!({"type": "firstlast"}))),
+            parse_sparse_index(Some(serde_json::Value::Null)).unwrap(),
             vec![]
         );
     }
 
     #[test]
-    fn unbacked_flags_firstlast_missing_in_source() {
-        let target = vec![entry("minmax", "time"), entry("firstlast", "value")];
-        let source = vec![entry("minmax", "time")];
+    fn parse_sparse_index_errors_on_malformed_entries() {
+        for malformed in [
+            json!([{"type": "firstlast"}]),
+            json!([{"column": "orphan"}]),
+            json!([{"type": 42, "column": "value"}]),
+            json!(["not-an-object"]),
+        ] {
+            assert!(
+                parse_sparse_index(Some(malformed.clone())).is_err(),
+                "expected {malformed} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_sparse_index_errors_on_non_array() {
+        assert!(parse_sparse_index(Some(json!({"type": "firstlast"}))).is_err());
+    }
+
+    #[test]
+    fn unbacked_flags_firstlast_without_backing_columns() {
+        let index = vec![entry("minmax", "time"), entry("firstlast", "value")];
+        let present = columns(&["_ts_meta_min_1", "_ts_meta_max_1"]);
         assert_eq!(
-            unbacked_sparse_index_entries(&target, &source),
+            unbacked_entries(&index, &present),
+            vec![&entry("firstlast", "value")],
+        );
+    }
+
+    #[test]
+    fn unbacked_flags_firstlast_with_only_one_backing_column() {
+        let index = vec![entry("firstlast", "value")];
+        let present = columns(&["_ts_meta_v2_first_value"]);
+        assert_eq!(
+            unbacked_entries(&index, &present),
             vec![&entry("firstlast", "value")],
         );
     }
 
     #[test]
     fn unbacked_ignores_minmax() {
-        let target = vec![entry("minmax", "time"), entry("minmax", "value")];
-        let source = vec![];
-        assert!(unbacked_sparse_index_entries(&target, &source).is_empty());
+        let index = vec![entry("minmax", "time"), entry("minmax", "value")];
+        assert!(unbacked_entries(&index, &columns(&[])).is_empty());
     }
 
     #[test]
-    fn unbacked_empty_when_source_backs_all_entries() {
-        let target = vec![entry("minmax", "time"), entry("firstlast", "value")];
-        let source = vec![entry("firstlast", "value")];
-        assert!(unbacked_sparse_index_entries(&target, &source).is_empty());
-    }
-
-    #[test]
-    fn unbacked_empty_when_source_is_superset() {
-        let target = vec![entry("firstlast", "value")];
-        let source = vec![entry("firstlast", "value"), entry("firstlast", "other")];
-        assert!(unbacked_sparse_index_entries(&target, &source).is_empty());
+    fn unbacked_empty_when_columns_back_all_entries() {
+        let index = vec![entry("minmax", "time"), entry("firstlast", "value")];
+        let present = columns(&["_ts_meta_v2_first_value", "_ts_meta_v2_last_value"]);
+        assert!(unbacked_entries(&index, &present).is_empty());
     }
 
     #[test]
     fn unbacked_matches_on_column_not_just_kind() {
-        let target = vec![entry("firstlast", "value")];
-        let source = vec![entry("firstlast", "other")];
+        let index = vec![entry("firstlast", "value")];
+        let present = columns(&["_ts_meta_v2_first_other", "_ts_meta_v2_last_other"]);
         assert_eq!(
-            unbacked_sparse_index_entries(&target, &source),
+            unbacked_entries(&index, &present),
             vec![&entry("firstlast", "value")],
         );
+    }
+
+    #[test]
+    fn unbacked_flags_unknown_entry_types() {
+        // An entry type whose physical layout we don't know must fail closed,
+        // even when the chunk carries plenty of metadata columns.
+        let index = vec![entry("bloom", "value")];
+        let present = columns(&[
+            "_ts_meta_v2_first_value",
+            "_ts_meta_v2_last_value",
+            "_ts_meta_v2_bloom1_value",
+        ]);
+        assert_eq!(
+            unbacked_entries(&index, &present),
+            vec![&entry("bloom", "value")],
+        );
+    }
+
+    #[test]
+    fn backing_columns_are_the_v2_first_and_last_columns() {
+        assert_eq!(
+            sparse_index_backing_columns(&entry("firstlast", "time")),
+            Some(vec![
+                "_ts_meta_v2_first_time".to_string(),
+                "_ts_meta_v2_last_time".to_string(),
+            ]),
+        );
+        assert_eq!(sparse_index_backing_columns(&entry("bloom", "time")), None);
+    }
+
+    #[test]
+    fn decompress_failure_context_names_issue_195_only_when_unbacked() {
+        let chunk = TargetChunk {
+            schema: "_timescaledb_internal".to_string(),
+            table: "_hyper_1_1_chunk".to_string(),
+            hypertable: Hypertable {
+                schema: "public".to_string(),
+                table: "metrics".to_string(),
+            },
+            dimensions: vec![],
+        };
+        assert!(!decompress_failure_context(&chunk, &[]).contains("195"));
+        let with_unbacked = decompress_failure_context(&chunk, &["firstlast on time".to_string()]);
+        assert!(with_unbacked.contains("195"));
+        assert!(with_unbacked.contains("firstlast on time"));
     }
 }

--- a/src/features.rs
+++ b/src/features.rs
@@ -13,6 +13,7 @@ static COMPRESSION_SETTINGS_WITH_COMPRESS_RELID: OnceLock<bool> = OnceLock::new(
 static HYPERCORE_TAM: OnceLock<bool> = OnceLock::new();
 static CAGG_INVALIDATION_TRIGGER: OnceLock<bool> = OnceLock::new();
 static CHUNK_CATALOG_USES_RELID: OnceLock<bool> = OnceLock::new();
+static HYPERTABLE_SPARSE_INDEX_METADATA: OnceLock<bool> = OnceLock::new();
 
 pub async fn initialize_features(target: &Target) -> Result<()> {
     let mut ts_version = Version::parse(&fetch_tsdb_version(&target.client).await?)?;
@@ -26,6 +27,7 @@ pub async fn initialize_features(target: &Target) -> Result<()> {
     let pg_version = fetch_pg_version_number(&target.client).await?;
 
     let ts_ge_229 = VersionReq::parse(">=2.29.0").unwrap().matches(ts_version);
+    let ts_ge_228 = VersionReq::parse(">=2.28.0").unwrap().matches(ts_version);
     let ts_lt_223 = VersionReq::parse("<2.23.0").unwrap().matches(ts_version);
     let ts_lt_222 = VersionReq::parse("<2.22.0").unwrap().matches(ts_version);
     let ts_ge_219 = VersionReq::parse(">=2.19.0").unwrap().matches(ts_version);
@@ -77,6 +79,10 @@ pub async fn initialize_features(target: &Target) -> Result<()> {
     CHUNK_CATALOG_USES_RELID
         .set(ts_ge_229)
         .map_err(|e| anyhow!("CHUNK_CATALOG_USES_RELID already set to {}", e))?;
+
+    HYPERTABLE_SPARSE_INDEX_METADATA
+        .set(ts_ge_228)
+        .map_err(|e| anyhow!("HYPERTABLE_SPARSE_INDEX_METADATA already set to {}", e))?;
     Ok(())
 }
 
@@ -136,4 +142,15 @@ pub fn chunk_catalog_uses_relid() -> bool {
     *CHUNK_CATALOG_USES_RELID
         .get()
         .expect("CHUNK_CATALOG_USES_RELID is not set")
+}
+
+// Starting with TS 2.28 the hypertable-level `compression_settings.index`
+// carries sparse-index metadata entries (e.g. `firstlast`) that
+// `create_compressed_chunk` copies verbatim onto each new chunk. A chunk
+// compressed under an older format lacks the physical `_ts_meta_*` columns
+// backing those entries, so the copied metadata dangles. See issue #195.
+pub fn hypertable_sparse_index_metadata() -> bool {
+    *HYPERTABLE_SPARSE_INDEX_METADATA
+        .get()
+        .expect("HYPERTABLE_SPARSE_INDEX_METADATA is not set")
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,6 +1,7 @@
 use crate::connect::{Source, Target};
 use crate::execute::{
-    create_compressed_chunk_without_data, create_uncompressed_chunk, get_compressed_chunk,
+    create_compressed_chunk_without_data, create_uncompressed_chunk, fetch_hypertable_sparse_index,
+    get_compressed_chunk, unbacked_sparse_index_metadata, SparseIndexEntry,
 };
 use crate::sql::assert_regex;
 use crate::storage::{backfill_schema_exists, init_schema};
@@ -10,7 +11,7 @@ use crate::timescale::{
 };
 use crate::{features, TERM};
 use anyhow::{bail, Result};
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::error::Error;
 use std::fmt;
 use tokio_postgres::error::SqlState;
@@ -240,6 +241,14 @@ pub async fn load_queue(
     }
 
     let mut skipped_chunks = 0;
+    // Source chunks that can't be copied in compressed form, and the
+    // sparse-index entries they can't back (see issue #195).
+    let mut uncompressed_fallbacks: Vec<String> = vec![];
+    let mut unbacked_entries: BTreeSet<String> = BTreeSet::new();
+    // The sparse-index entries each target hypertable declares, keyed by its
+    // quoted name. Invariant per hypertable, so it's queried once and reused
+    // across that hypertable's chunks.
+    let mut hypertable_sparse_index: HashMap<String, Vec<SparseIndexEntry>> = HashMap::new();
 
     let hypertables: Vec<String> = rows
         .iter()
@@ -322,8 +331,41 @@ pub async fn load_queue(
             if let Some(source_compressed_chunk) =
                 get_compressed_chunk(&source_tx, &source_chunk).await?
             {
-                // Check if target compressed chunk already exists
-                if get_compressed_chunk(&target_tx, &target_chunk)
+                // A chunk compressed under an older format can't be copied in
+                // compressed form: its layout doesn't back the sparse-index
+                // metadata the target hypertable declares (issue #195). Skip
+                // pre-creating the target compressed chunk for it and warn: the
+                // copy decision is `copy`'s, which re-runs this same detection
+                // per chunk, so the skip is only bookkeeping consistent with
+                // what `copy` will do.
+                //
+                // The target hypertable's declared index is invariant per
+                // hypertable, so cache it instead of querying it once per chunk.
+                let hypertable = target_chunk.hypertable.quoted_name();
+                if !hypertable_sparse_index.contains_key(&hypertable) {
+                    let index =
+                        fetch_hypertable_sparse_index(&target_tx, &target_chunk.hypertable).await?;
+                    hypertable_sparse_index.insert(hypertable.clone(), index);
+                }
+                let unbacked = unbacked_sparse_index_metadata(
+                    &source_tx,
+                    &source_compressed_chunk,
+                    &hypertable_sparse_index[&hypertable],
+                )
+                .await?;
+
+                if !unbacked.is_empty() {
+                    debug!(
+                        "Source chunk {} cannot back the sparse-index metadata of hypertable {} ({}); it will be copied uncompressed",
+                        source_chunk.quoted_name(),
+                        target_chunk.hypertable.quoted_name(),
+                        unbacked.join(", "),
+                    );
+                    uncompressed_fallbacks.push(source_chunk.quoted_name());
+                    for entry in unbacked {
+                        unbacked_entries.insert(entry);
+                    }
+                } else if get_compressed_chunk(&target_tx, &target_chunk)
                     .await?
                     .is_none()
                 {
@@ -353,9 +395,80 @@ pub async fn load_queue(
         ))?;
     }
 
+    if !uncompressed_fallbacks.is_empty() {
+        TERM.write_line(&uncompressed_fallback_warning(
+            &uncompressed_fallbacks,
+            &unbacked_entries,
+        ))?;
+    }
+
     let staged_tasks = chunk_count - skipped_chunks;
 
     Ok(staged_tasks)
+}
+
+/// How many of the affected chunks the fallback warning lists by name before
+/// summarizing the rest.
+const UNCOMPRESSED_FALLBACK_LISTED_CHUNKS: usize = 5;
+
+/// Builds the `stage` warning for source chunks that can't be copied in
+/// compressed form because they were compressed under a format that doesn't
+/// back the sparse-index metadata the target hypertables declare (issue #195).
+fn uncompressed_fallback_warning(chunks: &[String], unbacked_entries: &BTreeSet<String>) -> String {
+    let mut listed: Vec<String> = chunks
+        .iter()
+        .take(UNCOMPRESSED_FALLBACK_LISTED_CHUNKS)
+        .map(|chunk| format!("- {chunk}"))
+        .collect();
+    if let Some(remaining) = chunks.len().checked_sub(listed.len()).filter(|r| *r > 0) {
+        listed.push(format!(
+            "- ...and {remaining} more (set RUST_LOG=debug to list them all)"
+        ));
+    }
+
+    let (subject, pronoun) = if chunks.len() == 1 {
+        ("chunk", "It was")
+    } else {
+        ("chunks", "They were")
+    };
+
+    format!(
+        r"
+WARNING: {chunk_count} {subject} will be copied uncompressed.
+
+{pronoun} compressed in the source under an older TimescaleDB format that
+cannot back the sparse-index metadata declared by the target hypertables
+({entries}). Copying them in compressed form would corrupt the catalog
+metadata of the target chunks, so their rows are copied uncompressed and the
+target chunks are compressed again afterwards, in the target's own format.
+This is slower than a compressed copy, but the data is complete either way.
+See https://github.com/timescale/timescaledb-backfill/issues/195.
+
+{listed}
+
+To copy them in compressed form instead, rebuild them in the source so their
+physical layout matches the current compression format, and run `copy` again.
+This only helps once the source extension is itself on the version that
+declares these entries; on an older source the rebuilt chunks keep the layout
+they have now:
+
+    SELECT decompress_chunk(chunk), compress_chunk(chunk)
+    FROM (
+        SELECT format('%I.%I', chunk_schema, chunk_name)::regclass AS chunk
+        FROM timescaledb_information.chunks
+        WHERE hypertable_schema = '<schema>'
+          AND hypertable_name = '<table>'
+          AND is_compressed
+    ) c;
+",
+        chunk_count = chunks.len(),
+        entries = unbacked_entries
+            .iter()
+            .cloned()
+            .collect::<Vec<String>>()
+            .join(", "),
+        listed = listed.join("\n"),
+    )
 }
 
 async fn get_pending_task_count(client: &Client, task: &TaskType) -> Result<u64> {

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 use std::process::{Child, Command, Output, Stdio};
 use strip_ansi_escapes::strip;
 use tap_reader::Tap;
-use test_common::TsVersion::{TS223, TS225, TS226};
+use test_common::TsVersion::{TS223, TS225, TS226, TS228};
 use test_common::*;
 use testcontainers::clients::Cli;
 use tracing::debug;
@@ -1537,6 +1537,86 @@ fn clean_removes_schema() -> Result<()> {
         .unwrap()
         .with_name("target")
         .not_has_schema("__backfill");
+
+    Ok(())
+}
+
+/// A chunk compressed under a pre-2.28 format carries `minmax` sparse-index
+/// metadata only. When such a chunk is backfilled into a target whose
+/// hypertable was configured under TS 2.28, `create_compressed_chunk` copies
+/// the target's hypertable-level index (which includes `firstlast`) onto the
+/// new chunk, referencing physical `_ts_meta_*` columns the copied data lacks
+/// and corrupting its catalog (issue #195). The copy must instead fail loudly
+/// with remediation guidance.
+///
+/// The old-format source chunk is reproduced by compressing under TS 2.27.2 and
+/// then upgrading the source to the target version: an existing hypertable's
+/// compression settings are not rewritten on upgrade, so its chunks keep the
+/// minmax-only layout. The target hypertable is configured natively under 2.28,
+/// so its index advertises `firstlast`. This relies on the 2.28 image still
+/// shipping the 2.27.2 library, so other versions are skipped.
+#[test]
+fn stage_fails_on_unbacked_sparse_index_metadata() -> Result<()> {
+    if ts_version() != TS228 {
+        return Ok(());
+    }
+
+    let _ = pretty_env_logger::try_init();
+
+    let docker = Cli::default();
+
+    let source_container = docker.run(timescaledb(pg_version(), ts_version()));
+    let target_container = docker.run(timescaledb(pg_version(), ts_version()));
+
+    // Source: compress under a pre-2.28 format so the chunk's physical layout
+    // and per-chunk compression metadata carry `minmax` only.
+    psql(
+        &source_container,
+        PsqlInput::Sql(
+            "DROP EXTENSION IF EXISTS timescaledb CASCADE; CREATE EXTENSION timescaledb VERSION '2.27.2';",
+        ),
+    )?;
+    psql(&source_container, PsqlInput::Sql(SETUP_HYPERTABLE))?;
+    psql(&source_container, PsqlInput::Sql(INSERT_DATA_FOR_MAY))?;
+    psql(
+        &source_container,
+        PsqlInput::Sql(ENABLE_HYPERTABLE_COMPRESSION),
+    )?;
+    psql(&source_container, PsqlInput::Sql(COMPRESS_ALL_CHUNKS))?;
+
+    // Upgrade the source to the target version. `ALTER EXTENSION UPDATE` must
+    // run as the first statement of a fresh session, which a separate `psql`
+    // invocation provides. The already-compressed chunk keeps its minmax-only
+    // layout.
+    psql(
+        &source_container,
+        PsqlInput::Sql("ALTER EXTENSION timescaledb UPDATE;"),
+    )?;
+
+    // Target: configure compression natively under TS 2.28, so the
+    // hypertable-level index advertises `firstlast` (unlike the old source
+    // chunk).
+    psql(&target_container, PsqlInput::Sql(SETUP_HYPERTABLE))?;
+    psql(
+        &target_container,
+        PsqlInput::Sql(ENABLE_HYPERTABLE_COMPRESSION),
+    )?;
+
+    // `stage` pre-creates the target compressed chunk structure (via
+    // `create_compressed_chunk_without_data`), which is where the mismatch is
+    // detected, so the guard fails here before any data is copied.
+    run_backfill(TestConfigStage::new(
+        &source_container,
+        &target_container,
+        "2023-06-01T00:00:00",
+    ))?
+    .assert()
+    .failure()
+    .stderr(contains("Sparse-index metadata mismatch"))
+    .stderr(contains(
+        "https://github.com/timescale/timescaledb-backfill/issues/195",
+    ))
+    .stderr(contains("firstlast on time"));
 
     Ok(())
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1541,23 +1541,108 @@ fn clean_removes_schema() -> Result<()> {
     Ok(())
 }
 
+/// Fails when a compressed chunk's catalog metadata declares a `firstlast`
+/// sparse-index entry that its physical table can't back, which is the
+/// corruption of issue #195.
+///
+/// Row and chunk counts can't stand in for this: PG17 tolerates the dangling
+/// metadata, so every count assertion passes on PG17 even when the compressed
+/// copy path ran and corrupted the chunk. Asserting the invariant directly is
+/// what makes the test fail when the fallback stops firing.
+static ASSERT_SPARSE_INDEX_METADATA_IS_BACKED: &str = r"
+DO $$
+DECLARE
+    unbacked text;
+BEGIN
+    SELECT string_agg(format('%s on %s of %s', e->>'type', e->>'column', cs.compress_relid), ', ')
+    INTO unbacked
+    FROM _timescaledb_catalog.compression_settings cs
+    CROSS JOIN LATERAL jsonb_array_elements(cs.index) e
+    WHERE cs.compress_relid IS NOT NULL
+      AND e->>'type' = 'firstlast'
+      AND 2 <> (
+          SELECT count(*)
+          FROM pg_attribute a
+          WHERE a.attrelid = cs.compress_relid
+            AND NOT a.attisdropped
+            AND a.attname IN (
+                '_ts_meta_v2_first_' || (e->>'column'),
+                '_ts_meta_v2_last_' || (e->>'column')
+            )
+      );
+    IF unbacked IS NOT NULL THEN
+        RAISE EXCEPTION 'sparse-index metadata without backing columns: %', unbacked;
+    END IF;
+END $$;
+";
+
+/// The issue #195 setup: a source whose chunks were compressed under TS 2.27.2,
+/// so their physical layout and per-chunk metadata carry `minmax` only, and a
+/// target whose hypertable was configured natively under TS 2.28, so its
+/// hypertable-level index advertises `firstlast`.
+///
+/// The old-format source chunk is reproduced by compressing under 2.27.2 and
+/// then upgrading the source to the target version: an existing hypertable's
+/// compression settings are not rewritten on upgrade, so its chunks keep the
+/// minmax-only layout.
+fn setup_unbacked_sparse_index_metadata(
+    source_container: &impl HasConnectionString,
+    target_container: &impl HasConnectionString,
+) -> Result<()> {
+    psql(
+        source_container,
+        PsqlInput::Sql(
+            "DROP EXTENSION IF EXISTS timescaledb CASCADE; CREATE EXTENSION timescaledb VERSION '2.27.2';",
+        ),
+    )?;
+    psql(source_container, PsqlInput::Sql(SETUP_HYPERTABLE))?;
+    psql(source_container, PsqlInput::Sql(INSERT_DATA_FOR_MAY))?;
+    psql(
+        source_container,
+        PsqlInput::Sql(ENABLE_HYPERTABLE_COMPRESSION),
+    )?;
+    psql(source_container, PsqlInput::Sql(COMPRESS_ALL_CHUNKS))?;
+
+    // `ALTER EXTENSION UPDATE` must run as the first statement of a fresh
+    // session, which a separate `psql` invocation provides. The
+    // already-compressed chunks keep their minmax-only layout.
+    psql(
+        source_container,
+        PsqlInput::Sql("ALTER EXTENSION timescaledb UPDATE;"),
+    )?;
+
+    psql(target_container, PsqlInput::Sql(SETUP_HYPERTABLE))?;
+    psql(
+        target_container,
+        PsqlInput::Sql(ENABLE_HYPERTABLE_COMPRESSION),
+    )?;
+
+    Ok(())
+}
+
+/// Reports a version-gated skip. A bare `return Ok(())` reports success with no
+/// trace of having skipped, and these tests run on one version only: they need
+/// the 2.28 image to still ship the 2.27.2 library, and CI also exercises 2.27,
+/// 2.29 and nightly.
+fn skips_unless_ts228(test: &str) -> bool {
+    if ts_version() == TS228 {
+        return false;
+    }
+    eprintln!("SKIPPED {test}: requires TimescaleDB 2.28");
+    true
+}
+
 /// A chunk compressed under a pre-2.28 format carries `minmax` sparse-index
 /// metadata only. When such a chunk is backfilled into a target whose
 /// hypertable was configured under TS 2.28, `create_compressed_chunk` copies
 /// the target's hypertable-level index (which includes `firstlast`) onto the
 /// new chunk, referencing physical `_ts_meta_*` columns the copied data lacks
-/// and corrupting its catalog (issue #195). The copy must instead fail loudly
-/// with remediation guidance.
-///
-/// The old-format source chunk is reproduced by compressing under TS 2.27.2 and
-/// then upgrading the source to the target version: an existing hypertable's
-/// compression settings are not rewritten on upgrade, so its chunks keep the
-/// minmax-only layout. The target hypertable is configured natively under 2.28,
-/// so its index advertises `firstlast`. This relies on the 2.28 image still
-/// shipping the 2.27.2 library, so other versions are skipped.
+/// and corrupting its catalog (issue #195). Such chunks must instead be copied
+/// uncompressed and compressed again in the target's own format, with `stage`
+/// warning about it up front.
 #[test]
-fn stage_fails_on_unbacked_sparse_index_metadata() -> Result<()> {
-    if ts_version() != TS228 {
+fn copy_falls_back_to_uncompressed_on_unbacked_sparse_index_metadata() -> Result<()> {
+    if skips_unless_ts228("copy_falls_back_to_uncompressed_on_unbacked_sparse_index_metadata") {
         return Ok(());
     }
 
@@ -1568,55 +1653,108 @@ fn stage_fails_on_unbacked_sparse_index_metadata() -> Result<()> {
     let source_container = docker.run(timescaledb(pg_version(), ts_version()));
     let target_container = docker.run(timescaledb(pg_version(), ts_version()));
 
-    // Source: compress under a pre-2.28 format so the chunk's physical layout
-    // and per-chunk compression metadata carry `minmax` only.
-    psql(
-        &source_container,
-        PsqlInput::Sql(
-            "DROP EXTENSION IF EXISTS timescaledb CASCADE; CREATE EXTENSION timescaledb VERSION '2.27.2';",
-        ),
-    )?;
-    psql(&source_container, PsqlInput::Sql(SETUP_HYPERTABLE))?;
-    psql(&source_container, PsqlInput::Sql(INSERT_DATA_FOR_MAY))?;
-    psql(
-        &source_container,
-        PsqlInput::Sql(ENABLE_HYPERTABLE_COMPRESSION),
-    )?;
-    psql(&source_container, PsqlInput::Sql(COMPRESS_ALL_CHUNKS))?;
+    setup_unbacked_sparse_index_metadata(&source_container, &target_container)?;
 
-    // Upgrade the source to the target version. `ALTER EXTENSION UPDATE` must
-    // run as the first statement of a fresh session, which a separate `psql`
-    // invocation provides. The already-compressed chunk keeps its minmax-only
-    // layout.
-    psql(
-        &source_container,
-        PsqlInput::Sql("ALTER EXTENSION timescaledb UPDATE;"),
-    )?;
-
-    // Target: configure compression natively under TS 2.28, so the
-    // hypertable-level index advertises `firstlast` (unlike the old source
-    // chunk).
-    psql(&target_container, PsqlInput::Sql(SETUP_HYPERTABLE))?;
-    psql(
-        &target_container,
-        PsqlInput::Sql(ENABLE_HYPERTABLE_COMPRESSION),
-    )?;
-
-    // `stage` pre-creates the target compressed chunk structure (via
-    // `create_compressed_chunk_without_data`), which is where the mismatch is
-    // detected, so the guard fails here before any data is copied.
+    // `stage` skips pre-creating the target compressed chunk structure for the
+    // affected chunks and reports them, so the user knows before `copy` runs
+    // that they won't be copied in compressed form.
     run_backfill(TestConfigStage::new(
         &source_container,
         &target_container,
         "2023-06-01T00:00:00",
     ))?
     .assert()
-    .failure()
-    .stderr(contains("Sparse-index metadata mismatch"))
-    .stderr(contains(
+    .success()
+    .stdout(contains("WARNING: 5 chunks will be copied uncompressed."))
+    .stdout(contains("firstlast on time"))
+    .stdout(contains(
         "https://github.com/timescale/timescaledb-backfill/issues/195",
-    ))
-    .stderr(contains("firstlast on time"));
+    ));
+
+    // `copy` re-runs the detection per chunk and says so, so a fallback that
+    // stops firing is visible in the output and not only in the catalog.
+    run_backfill(TestConfigCopy::new(&source_container, &target_container))?
+        .assert()
+        .success()
+        .stdout(contains(
+            "copying its rows uncompressed and recompressing in target",
+        ));
+
+    psql(
+        &target_container,
+        PsqlInput::Sql(ASSERT_SPARSE_INDEX_METADATA_IS_BACKED),
+    )?;
+
+    let mut source_dbassert =
+        DbAssert::new(&source_container.connection_string())?.with_name("source");
+    let mut target_dbassert =
+        DbAssert::new(&target_container.connection_string())?.with_name("target");
+
+    // Counting the rows also proves the target chunks are queryable: with the
+    // copied-but-unbacked metadata, planning over them fails with `cache lookup
+    // failed for attribute 0` on PG16.
+    for dbassert in [&mut source_dbassert, &mut target_dbassert] {
+        dbassert
+            .has_table_count("public", "metrics", 744)
+            .has_chunk_count("public", "metrics", 5)
+            .has_compressed_chunk_count("public", "metrics", 5);
+    }
+
+    run_backfill(TestConfigVerify::new(&source_container, &target_container))?
+        .assert()
+        .success()
+        .stdout(contains("Chunk verification failed").not());
+
+    Ok(())
+}
+
+/// The fallback must also win over the completion-filter path. A `--until` that
+/// falls inside a chunk makes `copy` read that chunk's rows uncompressed to
+/// apply the filter, and that path recompresses the target chunk only when it
+/// was already compressed, which `stage` deliberately skips for the affected
+/// chunks. Detecting the mismatch first is what keeps the boundary chunk from
+/// staying uncompressed forever.
+#[test]
+fn filtered_copy_still_recompresses_on_unbacked_sparse_index_metadata() -> Result<()> {
+    if skips_unless_ts228("filtered_copy_still_recompresses_on_unbacked_sparse_index_metadata") {
+        return Ok(());
+    }
+
+    let _ = pretty_env_logger::try_init();
+
+    let docker = Cli::default();
+
+    let source_container = docker.run(timescaledb(pg_version(), ts_version()));
+    let target_container = docker.run(timescaledb(pg_version(), ts_version()));
+
+    setup_unbacked_sparse_index_metadata(&source_container, &target_container)?;
+
+    // The default 7-day chunks are epoch-aligned, so the last chunk covers
+    // 2023-05-25 to 2023-06-01 and this boundary falls inside it.
+    run_backfill(TestConfigStage::new(
+        &source_container,
+        &target_container,
+        "2023-05-28T00:00:00",
+    ))?
+    .assert()
+    .success()
+    .stdout(contains("WARNING: 5 chunks will be copied uncompressed."));
+
+    run_backfill(TestConfigCopy::new(&source_container, &target_container))?
+        .assert()
+        .success();
+
+    psql(
+        &target_container,
+        PsqlInput::Sql(ASSERT_SPARSE_INDEX_METADATA_IS_BACKED),
+    )?;
+
+    // Hourly rows from 2023-05-01T00:00 up to (but not including) the boundary.
+    DbAssert::new(&target_container.connection_string())?
+        .with_name("target")
+        .has_table_count("public", "metrics", 27 * 24)
+        .has_chunk_count("public", "metrics", 5)
+        .has_compressed_chunk_count("public", "metrics", 5);
 
     Ok(())
 }


### PR DESCRIPTION
## Why

Fixes #195.

Backfilling a chunk that was compressed under a pre-2.28 TimescaleDB format
into a target whose hypertable was configured under TS 2.28 corrupts the target
chunk's catalog. The old chunk carries `minmax` sparse-index metadata only, but
`create_compressed_chunk` copies the target hypertable-level index (which
includes `firstlast`) onto the new chunk. The copied `firstlast` entry
references physical `_ts_meta_*` columns the data lacks, so on PG16 targets
every query over the chunk fails with `cache lookup failed for attribute 0`; on
PG17 the planner silently tolerates the dangling metadata.

Reconciling the catalog after the fact isn't an option on Tiger Cloud
(`tsdbadmin` has no `UPDATE` on `compression_settings`), and there's no GUC to
suppress the copy.

Failing the backfill outright would leave users of an older source with no way
forward: rebuilding the source chunks only produces a compatible layout once the
source extension is itself on 2.28. These chunks can still be copied correctly,
just not in compressed form, so the tool takes that path instead of refusing to
migrate.

## What

- Detect the mismatch and copy the affected chunks uncompressed, letting the
  target compress them in its own format. Detection compares the target
  hypertable's declared sparse-index entries against the physical `_ts_meta_*`
  columns the source compressed chunk actually has, so it tests catalog against
  layout, which is where the drift lives.
- Report the affected chunks during `stage`, before any data moves, and skip
  pre-creating their target compressed chunk structure. The warning names the
  chunk count, the unbacked entries, the issue, and the remediation for copying
  them compressed instead.
- Decide this before the completion-filter branch in `copy`, which recompresses
  the target chunk only when it was already compressed. Otherwise the chunk
  holding the `--until` boundary would stay uncompressed forever.
- Diagnose a target compressed chunk pre-created by an older binary before
  decompressing it, so PG16 reports what actually happened instead of surfacing
  `cache lookup failed for attribute 0`.
- Fail closed throughout: an unrecognized `compression_settings.index` shape, a
  malformed entry and a missing settings row are all errors, and an entry type
  the tool doesn't know is treated as unbacked.
- Gate the check on target TS >= 2.28 (`hypertable_sparse_index_metadata`).

## Tests

- Unit tests for the parsing, the backing-column mapping and the unbacked
  comparison, including the fail-closed cases.
- `copy_falls_back_to_uncompressed_on_unbacked_sparse_index_metadata` reproduces
  the scenario end-to-end: compress the source under TS 2.27.2, upgrade the
  source to 2.28, configure the target natively under 2.28, then assert the
  stage warning, the copy-time fallback, 744 rows in 5 compressed chunks, and a
  clean `verify`.
- `filtered_copy_still_recompresses_on_unbacked_sparse_index_metadata` stages
  with an `--until` inside the last chunk and asserts the target still ends up
  with 5 compressed chunks.
- Both assert directly that every `firstlast` entry in the target's chunk-level
  `compression_settings.index` has both backing columns in `pg_attribute`. Row
  and chunk counts can't stand in for this: PG17 tolerates the dangling
  metadata, so every count assertion passes there even when the corrupt path
  ran.
- Version-gated skips now print `SKIPPED <test>: requires TimescaleDB 2.28`
  instead of reporting a silent success on the 2.27, 2.29 and nightly rows.
